### PR TITLE
fixed support for ID3v2.4

### DIFF
--- a/native/vendor/id3lib-3.8.3/src/header.cpp
+++ b/native/vendor/id3lib-3.8.3/src/header.cpp
@@ -36,12 +36,12 @@ bool ID3_Header::SetSpec(ID3_V2Spec spec)
   static ID3_Header::Info _spec_info[] =
   {
   // Warning, EXT SIZE are minimum sizes, they can be bigger
-  // SIZEOF SIZEOF SIZEOF IS EXT EXT  EXPERIM
-  // FRID   FRSZ   FRFL   HEADER SIZE BIT
-    {  3,     3,     0,     false, 0,   false }, // ID3V2_2_0
-    {  3,     3,     0,     true,  8,   true  }, // ID3V2_2_1
-    {  4,     4,     2,     false, 10,  false }, // ID3V2_3_0
-    {  4,     4,     2,     false, 6,   false }  // ID3V2_4_0
+    // SIZEOF SIZEOF SIZEOF IS EXT EXT  EXPERIM FRSIZE
+    // FRID   FRSZ   FRFL   HEADER SIZE BIT		SYNC
+    {  3,     3,     0,     false, 0,   false,  false  }, // ID3V2_2_0
+    {  3,     3,     0,     true,  8,   true,   false  }, // ID3V2_2_1
+    {  4,     4,     2,     false, 10,  false,  false  }, // ID3V2_3_0
+    {  4,     4,     2,     false, 6,   false,  true   }  // ID3V2_4_0
   };
   
   bool changed = false;

--- a/native/vendor/id3lib-3.8.3/src/header.h
+++ b/native/vendor/id3lib-3.8.3/src/header.h
@@ -46,6 +46,7 @@ public:
     bool       is_extended;
     size_t     extended_bytes; //including the extended header, so everything!
     bool       is_experimental;
+    bool       frame_size_synchsafe;
   };
 
   ID3_Header() 

--- a/native/vendor/id3lib-3.8.3/src/header_frame.cpp
+++ b/native/vendor/id3lib-3.8.3/src/header_frame.cpp
@@ -117,7 +117,16 @@ bool ID3_FrameHeader::Parse(ID3_Reader& reader)
     this->SetFrameID(fid);
   }
 
-  uint32 dataSize = io::readBENumber(reader, _info->frame_bytes_size);
+  uint32 dataSize;
+  
+  if (_info->frame_size_synchsafe && _info->frame_bytes_size == 4)
+  {
+    dataSize = io::readUInt28(reader);
+  }
+  else
+  {
+    dataSize = io::readBENumber(reader, _info->frame_bytes_size);
+  }
   ID3D_NOTICE( "ID3_FrameHeader::Parse: dataSize = " << dataSize );
   ID3D_NOTICE( "ID3_FrameHeader::Parse: getCur() = " << reader.getCur() );
   this->SetDataSize(dataSize);


### PR DESCRIPTION
the frame size was changed in ID3v2.4 from 32 bit integer to 28 bit synchsafe integer
