### PR TITLE
migrate TS cutter to node

### DIFF
--- a/native/common/include/ffprobe.h
+++ b/native/common/include/ffprobe.h
@@ -19,6 +19,7 @@ extern "C" {
 
 frame_info_t* get_frames(const char* ffprobe_bin, const char** files, int file_count, int* frame_count);
 frame_info_t* get_frames_single(const char* ffprobe_bin, const char* input_file, int* frame_count);
+frame_info_t* parse_ffprobe_output(char* input_buffer, int length, int* frame_count);
 
 #ifdef __cplusplus
 }

--- a/native/common/src/ffprobe.c
+++ b/native/common/src/ffprobe.c
@@ -115,3 +115,27 @@ frame_info_t* get_frames_single(const char* ffprobe_bin, const char* input_file,
 	files[0] = input_file;
 	return get_frames(ffprobe_bin, files, 1, frame_count);
 }
+
+frame_info_t* parse_ffprobe_output(char* input_buffer, int length, int* frame_count)
+{
+	get_frames_state_t state = { { 0 } };
+	char* end_pos = input_buffer + length;
+	char* new_line_pos;
+	char* cur_pos;
+	
+	for (cur_pos = input_buffer; cur_pos < end_pos; cur_pos = new_line_pos + 1)
+	{
+		new_line_pos = (char*)memchr(cur_pos, '\n', end_pos - cur_pos);
+		if (new_line_pos == NULL)
+		{
+			break;
+		}
+		
+		*new_line_pos = '\0';
+		
+		get_frames_callback(&state, cur_pos);
+	}
+
+	*frame_count = state.result.write_pos / sizeof(frame_info_t);
+	return (frame_info_t*)state.result.data;
+}

--- a/native/node_addons/TsCutter/MultiBuffer.js
+++ b/native/node_addons/TsCutter/MultiBuffer.js
@@ -1,0 +1,174 @@
+var tmp = require('tmp');
+var fs = require('fs');
+
+var MultiBuffer = function() {
+	this.buffers = [];
+};
+
+MultiBuffer.prototype.readFilesInternal = function(fileList, curIndex, callback) {
+	if (curIndex >= fileList.length) {
+		callback(null);
+		return;
+	}
+	
+	var This = this;
+	fs.readFile(fileList[curIndex], function (err, data) {
+		if (err) {
+			callback(err);
+			return;
+		}
+		
+		This.buffers.push(data);
+		This.readFilesInternal(fileList, curIndex + 1, callback)
+	});
+};
+
+MultiBuffer.prototype.readFiles = function(fileList, callback) {
+	this.readFilesInternal(fileList, 0, callback);
+};
+
+MultiBuffer.prototype.writeFileInternal = function(fd, bufferIndex, callback) {
+	if (bufferIndex >= this.buffers.length) {
+		fs.closeSync(fd);
+		callback();
+		return;
+	}
+	
+	var This = this;
+	fs.write(fd, this.buffers[bufferIndex], 0, this.buffers[bufferIndex].length, null, function (err, written, buffer) {
+		if (err) {
+			fs.closeSync(fd);
+			callback(err);
+			return;
+		}
+		
+		This.writeFileInternal(fd, bufferIndex + 1, callback);
+	});
+};
+
+MultiBuffer.prototype.writeFile = function(outputFile, callback) {
+	var This = this;
+	fs.open(outputFile, 'w', function (err, fd) {
+		if (err) {
+			callback(err);
+			return;
+		}
+		
+		This.writeFileInternal(fd, 0, callback);
+	});
+};
+
+MultiBuffer.prototype.writeTempFile = function(callback) {
+	var This = this;
+	tmp.file(function (err, outputFile, fd) {
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		fs.closeSync(fd);
+
+		This.writeFile(outputFile, function (err) {
+			if (err) {
+				callback(err);
+			}
+			else {
+				callback(null, outputFile);
+			}
+		});
+	});
+};
+
+MultiBuffer.prototype.getPosition = function(position) {
+	if (position < 0 && this.buffers.length > 0) {
+		// negative position indicates the end position
+		return {
+			index: this.buffers.length - 1,
+			position: this.buffers[this.buffers.length - 1].length
+		};
+	}
+	
+	var curPos = 0;
+	for (var i = 0; i < this.buffers.length; i++) {
+		if (position >= curPos && position < curPos + this.buffers[i].length) {
+			return { 
+				index: i, 
+				position: position - curPos
+			};
+		}
+		curPos += this.buffers[i].length;
+	}
+	return null;
+};
+
+MultiBuffer.prototype.push = function(buffer) {
+	this.buffers.push(buffer);
+};
+
+MultiBuffer.prototype.concat = function(multiBuffer) {
+	var result = new MultiBuffer();
+	result.buffers = this.buffers.concat(multiBuffer.buffers);
+	return result;
+};
+
+MultiBuffer.prototype.slice = function(startPos, endPos) {
+	var result = new MultiBuffer();
+	// validate start/end positions
+	if (startPos < 0 || (endPos > 0 && startPos >= endPos)) {
+		return result;
+	}
+	
+	// translate the positions to indexes
+	startPos = this.getPosition(startPos);
+	if (!startPos) {
+		// start position exceeds the buffer length => return empty
+		return result;
+	}
+
+	endPos = this.getPosition(endPos);
+	if (!endPos) {
+		// end position exceeds the buffer length => truncate it to the actual length
+		endPos = this.getPosition(-1);
+	}
+
+	// generate the slice
+	for (var curIndex = startPos.index; curIndex <= endPos.index; curIndex++) {
+		var curStart = 0;
+		if (curIndex == startPos.index) {
+			curStart = startPos.position;
+		}
+		var curEnd = this.buffers[curIndex].length;
+		if (curIndex == endPos.index) {
+			curEnd = endPos.position;
+		}
+		result.buffers.push(this.buffers[curIndex].slice(curStart, curEnd));
+	}
+	
+	return result;	
+}
+
+MultiBuffer.prototype.reverseWalk = function(endPos, callback) {
+	if (this.buffers.length == 0) {
+		return;
+	}
+	
+	endPos = this.getPosition(endPos);
+	if (!endPos) {
+		// end position exceeds buffer length, truncate to the actual length
+		endPos = this.getPosition(-1);
+	}
+	
+	var curIndex;
+	for (curIndex = endPos.index; curIndex >= 0; curIndex--) {
+		curEndPos = this.buffers[curIndex].length;
+		if (curIndex == endPos.index) {
+			curEndPos = endPos.position;
+		}
+		
+		if (!callback(this.buffers[curIndex].slice(0, curEndPos))) {
+			break;
+		}
+	}
+}
+
+module.exports.MultiBuffer = MultiBuffer;

--- a/native/node_addons/TsCutter/TsCutter.cc
+++ b/native/node_addons/TsCutter/TsCutter.cc
@@ -1,0 +1,348 @@
+#include <stdlib.h>
+#include "nan.h"
+#include "ts_cutter_impl.h"
+
+using namespace v8;
+using namespace node;
+
+dynamic_buffer_t* ParseArrayOfBuffers(Local<Value> value, size_t* resultCount)
+{
+	if (!value->IsArray())
+	{
+		return NULL;
+	}
+
+	Local<Array> buffersArray = value.As<Array>();
+	size_t buffersCount = buffersArray->Length();
+	if (buffersCount < 1)
+	{
+		return NULL;
+	}
+	
+	dynamic_buffer_t* buffers = (dynamic_buffer_t*)malloc(sizeof(dynamic_buffer_t) * buffersCount);
+	if (buffers == NULL)
+	{
+		return NULL;
+	}
+	
+	for (size_t i = 0; i < buffersCount; i++) 
+	{
+		if (!buffersArray->Get(i)->IsObject())
+		{
+			free(buffers);
+			return NULL;
+		}
+		
+		Local<Object> curObject = buffersArray->Get(i)->ToObject();
+		if (!Buffer::HasInstance(curObject))
+		{
+			free(buffers);
+			return NULL;
+		}
+	
+		buffers[i].data = (byte_t*)Buffer::Data(curObject);
+		buffers[i].write_pos = Buffer::Length(curObject);
+	}
+	
+	*resultCount = buffersCount;
+	
+	return buffers;
+}
+
+/*
+	Parameters
+		Array<Buffer> fileBuffers,
+		String framesInfo,
+		Number cutOffset
+		Boolean leftPortion
+		
+	Returns
+		Object
+*/
+NAN_METHOD(GetCutDetails) {
+	NanScope();
+	
+	if (args.Length() < 4) 
+	{
+		return NanThrowTypeError("Function requires 4 arguments");
+	}
+	
+	// validate frames info
+	if (!args[1]->IsString())
+	{
+		return NanThrowTypeError("Argument 2 must be a string");
+	}
+
+	v8::String::Utf8Value framesBuffer(args[1]);
+	
+	// validate cut position
+	if (!args[2]->IsNumber()) 
+	{
+		return NanThrowTypeError("Argument 3 must be a number");
+	}
+	
+	// validate left portion
+	if (!args[3]->IsBoolean()) 
+	{
+		return NanThrowTypeError("Argument 4 must be a boolean");
+	}
+
+	// parse file buffers
+	size_t fileBuffersCount;
+	dynamic_buffer_t* fileBuffers = ParseArrayOfBuffers(args[0], &fileBuffersCount);
+	if (fileBuffers == NULL)
+	{
+		return NanThrowTypeError("Argument 1 must be a non-empty array of buffers");
+	}
+	
+	// calculate the result	
+	bounding_iframes_t bounding_iframes; 
+	timestamps_t reference_timestamps[MEDIA_TYPE_COUNT];
+	
+	if (!get_cut_details(
+		fileBuffers,
+		fileBuffersCount,
+		*framesBuffer,
+		framesBuffer.length(),
+		args[2]->Int32Value(),
+		args[3]->BooleanValue(),
+		&bounding_iframes, 
+		reference_timestamps))
+	{
+		free(fileBuffers);
+		return NanThrowTypeError("Failed to get the cut details");
+	}
+
+	free(fileBuffers);
+	
+	Local<Object> timestamps = Object::New();
+	
+	Local<Object> audioTimestamps = Object::New();
+	audioTimestamps->Set(String::NewSymbol("pcr"), Number::New(reference_timestamps[MEDIA_TYPE_AUDIO].pcr));
+	audioTimestamps->Set(String::NewSymbol("pts"), Number::New(reference_timestamps[MEDIA_TYPE_AUDIO].pts));
+	audioTimestamps->Set(String::NewSymbol("dts"), Number::New(reference_timestamps[MEDIA_TYPE_AUDIO].dts));
+	timestamps->Set(String::NewSymbol("audio"), audioTimestamps);
+
+	Local<Object> videoTimestamps = Object::New();
+	videoTimestamps->Set(String::NewSymbol("pcr"), Number::New(reference_timestamps[MEDIA_TYPE_VIDEO].pcr));
+	videoTimestamps->Set(String::NewSymbol("pts"), Number::New(reference_timestamps[MEDIA_TYPE_VIDEO].pts));
+	videoTimestamps->Set(String::NewSymbol("dts"), Number::New(reference_timestamps[MEDIA_TYPE_VIDEO].dts));	
+	timestamps->Set(String::NewSymbol("video"), videoTimestamps);
+	
+	Local<Object> frames = Object::New();
+	frames->Set(String::NewSymbol("leftPos"), 		Number::New(bounding_iframes.left_iframe->pos));
+	frames->Set(String::NewSymbol("leftOffset"), 	Number::New(bounding_iframes.left_iframe_offset));
+	frames->Set(String::NewSymbol("rightPos"), 		Number::New(bounding_iframes.right_iframe->pos));
+	frames->Set(String::NewSymbol("rightOffset"), 	Number::New(bounding_iframes.right_iframe_offset));
+	
+	Local<Object> result = Object::New();
+	result->Set(String::NewSymbol("frames"), frames);
+	result->Set(String::NewSymbol("timestamps"), timestamps);
+	
+	NanReturnValue(result);
+}
+
+/*
+	Parameters
+		Buffer fileBuffer,
+		String framesInfo,
+		Object timestamps
+		Boolean leftPortion
+		
+	Returns
+		Undefined
+*/
+NAN_METHOD(FixTimestamps) {
+	NanScope();
+
+	if (args.Length() < 4) 
+	{
+		return NanThrowTypeError("Function requires 4 arguments");
+	}
+	
+	// validate source buffer
+	if (!args[0]->IsObject())
+	{
+		return NanThrowTypeError("Argument 1 must be a buffer");
+	}
+	
+	Local<Object> bufferObject = args[0]->ToObject();
+	if (!Buffer::HasInstance(bufferObject))
+	{
+		return NanThrowTypeError("Argument 1 must be a buffer");
+	}
+
+	// validate frames info
+	if (!args[1]->IsString())
+	{
+		return NanThrowTypeError("Argument 2 must be a string");
+	}
+
+	v8::String::Utf8Value framesBuffer(args[1]);
+
+	// validate timestamps
+	if (!args[2]->IsObject()) 
+	{
+		return NanThrowTypeError("Argument 3 must be an object");
+	}
+
+	Local<Object> timestampsObject = args[2]->ToObject();
+
+	Local<Value> audioValue = timestampsObject->Get(String::NewSymbol("audio"));
+	if (!audioValue->IsObject())
+	{
+		return NanThrowTypeError("Argument 3 must contain objects");
+	}
+	Local<Object> audioObject = audioValue->ToObject();
+
+	Local<Value> videoValue = timestampsObject->Get(String::NewSymbol("video"));
+	if (!videoValue->IsObject())
+	{
+		return NanThrowTypeError("Argument 3 must contain objects");
+	}
+	Local<Object> videoObject = videoValue->ToObject();
+	
+	timestamps_t reference_timestamps[MEDIA_TYPE_COUNT];
+	reference_timestamps[MEDIA_TYPE_AUDIO].pcr = audioObject->Get(String::NewSymbol("pcr"))->IntegerValue();
+	reference_timestamps[MEDIA_TYPE_AUDIO].pts = audioObject->Get(String::NewSymbol("pts"))->IntegerValue();
+	reference_timestamps[MEDIA_TYPE_AUDIO].dts = audioObject->Get(String::NewSymbol("dts"))->IntegerValue();
+	reference_timestamps[MEDIA_TYPE_VIDEO].pcr = videoObject->Get(String::NewSymbol("pcr"))->IntegerValue();
+	reference_timestamps[MEDIA_TYPE_VIDEO].pts = videoObject->Get(String::NewSymbol("pts"))->IntegerValue();
+	reference_timestamps[MEDIA_TYPE_VIDEO].dts = videoObject->Get(String::NewSymbol("dts"))->IntegerValue();
+	
+	// validate left portion
+	if (!args[3]->IsBoolean()) 
+	{
+		return NanThrowTypeError("Argument 4 must be a boolean");
+	}
+
+	// fix the timestamps
+	if (!fix_timestamps(
+		(byte_t*)Buffer::Data(bufferObject),
+		Buffer::Length(bufferObject),
+		*framesBuffer,
+		framesBuffer.length(),
+		reference_timestamps,
+		args[3]->BooleanValue()))
+	{
+		return NanThrowTypeError("Failed to fix timestamps");
+	}
+	
+	NanReturnUndefined();
+}
+
+/*
+	Parameters
+		Buffer fileBuffer
+		
+	Returns
+		Object
+*/
+NAN_METHOD(FindLastPatPmtPackets) {
+	NanScope();
+
+	if (args.Length() < 1) 
+	{
+		return NanThrowTypeError("Function requires 1 argument");
+	}
+	
+	// validate source buffer
+	if (!args[0]->IsObject())
+	{
+		return NanThrowTypeError("Argument 1 must be a buffer");
+	}
+	
+	Local<Object> bufferObject = args[0]->ToObject();
+	if (!Buffer::HasInstance(bufferObject))
+	{
+		return NanThrowTypeError("Argument 1 must be a buffer");
+	}
+	
+	byte_t* sourceBuffer = (byte_t*)Buffer::Data(bufferObject);
+	byte_t* lastPatPacket;
+	byte_t* lastPmtPacket;
+	
+	if (!find_last_pat_pmt_packets(
+		sourceBuffer,
+		Buffer::Length(bufferObject),
+		&lastPatPacket, 
+		&lastPmtPacket))
+	{
+		NanReturnNull();
+	}
+	
+	Local<Object> result = Object::New();
+	result->Set(String::NewSymbol("pat"), Number::New(lastPatPacket - sourceBuffer));
+	result->Set(String::NewSymbol("pmt"), Number::New(lastPmtPacket - sourceBuffer));
+	
+	NanReturnValue(result);
+}
+
+/*
+	Parameters
+		Array<Buffer> fileBuffers,
+		
+	Returns
+		Undefined
+*/
+NAN_METHOD(FixContinuityForward) {
+	NanScope();
+
+	if (args.Length() < 1) 
+	{
+		return NanThrowTypeError("Function requires 1 arguments");
+	}
+	
+	size_t fileBuffersCount;
+	dynamic_buffer_t* fileBuffers = ParseArrayOfBuffers(args[0], &fileBuffersCount);
+	if (fileBuffers == NULL)
+	{
+		return NanThrowTypeError("Argument 1 must be a non-empty array of buffers");
+	}
+
+	fix_continuity_forward(fileBuffers, fileBuffersCount);
+	
+	free(fileBuffers);
+	
+	NanReturnUndefined();
+}
+	
+/*
+	Parameters
+		Array<Buffer> fileBuffers,
+		
+	Returns
+		Undefined
+*/
+NAN_METHOD(FixContinuityBackward) {
+	NanScope();
+
+	if (args.Length() < 1) 
+	{
+		return NanThrowTypeError("Function requires 1 arguments");
+	}
+	
+	size_t fileBuffersCount;
+	dynamic_buffer_t* fileBuffers = ParseArrayOfBuffers(args[0], &fileBuffersCount);
+	if (fileBuffers == NULL)
+	{
+		return NanThrowTypeError("Argument 1 must be a non-empty array of buffers");
+	}
+
+	fix_continuity_backward(fileBuffers, fileBuffersCount);
+	
+	free(fileBuffers);
+	
+	NanReturnUndefined();
+}
+
+void init(Handle<Object> exports) 
+{
+	exports->Set(String::NewSymbol("getCutDetails"), FunctionTemplate::New(GetCutDetails)->GetFunction());
+	exports->Set(String::NewSymbol("fixTimestamps"), FunctionTemplate::New(FixTimestamps)->GetFunction());
+	exports->Set(String::NewSymbol("findLastPatPmtPackets"), FunctionTemplate::New(FindLastPatPmtPackets)->GetFunction());
+	exports->Set(String::NewSymbol("fixContinuityForward"), FunctionTemplate::New(FixContinuityForward)->GetFunction());
+	exports->Set(String::NewSymbol("fixContinuityBackward"), FunctionTemplate::New(FixContinuityBackward)->GetFunction());
+}
+
+NODE_MODULE(TsCutter, init)

--- a/native/node_addons/TsCutter/TsCutter.js
+++ b/native/node_addons/TsCutter/TsCutter.js
@@ -1,0 +1,279 @@
+var kalturaMediaInfo = require('../../../poc/node/KalturaMediaInfo');
+var kalturaFfmpegParams = require('../../../poc/node/KalturaFfmpegParams');
+var childProcess = require('child_process');
+var nativeCutter = require('./build/Release/TsCutter');
+var tmp = require('tmp');
+var fs = require('fs');
+var MultiBuffer = require('./MultiBuffer').MultiBuffer;
+
+const TS_PACKET_LENGTH = 188;
+const MAX_FFPROBE_OUTPUT_SIZE = 2 * 1024 * 1024;
+
+if (typeof String.prototype.startsWith != 'function') {
+  String.prototype.startsWith = function (str){
+    return this.slice(0, str.length) == str;
+  };
+}
+
+if (typeof String.prototype.endsWith != 'function') {
+  String.prototype.endsWith = function (str){
+    return this.slice(-str.length) == str;
+  };
+}
+
+function findLastPatPmtPackets(inputBuffers, endPos) {
+	var outputBuffers = new MultiBuffer();
+	inputBuffers.reverseWalk(endPos, function (curBuffer) {
+		var patPmtPackets = nativeCutter.findLastPatPmtPackets(curBuffer);
+		if (!patPmtPackets) {
+			return true;
+		}
+		
+		outputBuffers.push(curBuffer.slice(patPmtPackets.pat, patPmtPackets.pat + TS_PACKET_LENGTH));
+		outputBuffers.push(curBuffer.slice(patPmtPackets.pmt, patPmtPackets.pmt + TS_PACKET_LENGTH));
+		return false;
+	});
+
+	// Note: this is OK since reverseWalk is synchronous
+	return outputBuffers;
+}
+
+function buildTsBuffers(inputBuffers, startPos, endPos) {
+	var patPmtBuffers = findLastPatPmtPackets(inputBuffers, startPos);
+	if (!patPmtBuffers) {
+		return null;
+	}
+	
+	var bufferSlice = inputBuffers.slice(startPos, endPos)
+	if (!bufferSlice) {
+		return null;
+	}
+	
+	return patPmtBuffers.concat(bufferSlice);
+}
+
+function executeCommand(commandLine, options, callback) {
+	console.log('Executing ' + commandLine);
+	var startTime = new Date().getTime();
+	childProcess.exec(commandLine, options, function (error, stdout, stderr) {
+		var endTime = new Date().getTime();
+		console.log('Done, took ' + ((endTime - startTime) / 1000));
+		callback(error, stdout, stderr);
+	});
+}
+
+function getFramesInfo(ffprobeBin, inputFiles, callback) {
+	var ffprobeCmd = ffprobeBin + " -show_packets -i 'concat:" + inputFiles.join('|') + "'";
+
+	executeCommand(ffprobeCmd, { maxBuffer: MAX_FFPROBE_OUTPUT_SIZE }, function (error, framesInfo, stderr) {
+		callback(error, framesInfo);
+	});
+}
+
+function readFilesAndGetFrames(ffprobeBin, inputFiles, callback) {
+	// read the input files
+	var inputBuffers = new MultiBuffer();
+	inputBuffers.readFiles(inputFiles, function (error) {
+		if (error) {
+			callback(error);
+			return;
+		}
+		
+		// get the frames info
+		getFramesInfo(ffprobeBin, inputFiles, function (error, framesInfo) {
+			if (error) {
+				callback(error);
+				return;
+			}
+			
+			callback(null, inputBuffers, framesInfo);
+		});
+	});
+}
+
+function executeFfmpegWithTempOutput(ffmpegBin, params, callback) {
+	// create a temp file
+	tmp.file(function (err, outputFile, fd) {
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		fs.closeSync(fd);
+	
+		// execute ffmpeg
+		var ffmpegCmd = [ffmpegBin, params, '-y ' + outputFile].join(' ');
+		executeCommand(ffmpegCmd, {}, function (error, stdout, stderr) {
+
+			if (error) {
+				callback(error);
+			}
+			else {
+				callback(null, outputFile);
+			}
+		});			
+	});
+}
+
+function clipWithFfmpeg(ffmpegBin, ffprobeBin, inputBuffers, cutOffset, leftPortion, callback) {
+	// save the input buffers to a file
+	inputBuffers.writeTempFile(function (err, inputFile) {
+		if (err) {
+			callback(err);
+			return;
+		}
+
+		// parse the media info
+		kalturaMediaInfo.parse(inputFile, function (mediaInfo) {
+			console.log('Parsed media info:');
+			console.dir(mediaInfo);
+			
+			// build the encoding params
+			var encodingParams = kalturaFfmpegParams.buildEncodingParams(mediaInfo, leftPortion, false);			
+			var clipSwitch;
+			if (leftPortion) {
+				clipSwitch = '-t ' + cutOffset;
+			}
+			else {
+				clipSwitch = '-ss ' + cutOffset;
+			}
+			var ffmpegParams = ['-i ' + inputFile, encodingParams, clipSwitch].join(' ');
+			
+			// run ffmpeg with temp file output
+			executeFfmpegWithTempOutput(ffmpegBin, ffmpegParams, function (err, ffmpegClippedFile) {
+				if (err) {
+					callback(err);
+					return;
+				}
+				
+				// read the result
+				readFilesAndGetFrames(ffprobeBin, [ffmpegClippedFile], function (error, clippedBuffers, clippedFramesInfo) {
+					callback(error, clippedBuffers, clippedFramesInfo);
+				});
+			});
+		});
+	});
+}
+
+function cutTsFiles(outputFile, ffmpegBin, ffprobeBin, cutOffset, leftPortion, inputFiles, callback) {	
+	// read the input files
+	readFilesAndGetFrames(ffprobeBin, inputFiles, function (error, inputBuffers, framesInfo) {
+
+		if (error) {
+			callback(error);
+			return;
+		}
+		
+		// get the frame positions and timestamps
+		cutDetails = nativeCutter.getCutDetails(
+			inputBuffers.buffers,
+			framesInfo,
+			cutOffset,
+			leftPortion
+		);
+		console.log('Using the following parameters for the cut');
+		console.dir(cutDetails);
+		
+		// add the margins to the output buffers
+		var outputBuffers;
+		if (leftPortion) {
+			outputBuffers = inputBuffers.slice(0, cutDetails.frames.leftPos);
+		}
+		else {
+			outputBuffers = buildTsBuffers(inputBuffers, cutDetails.frames.rightPos, -1);			
+		}
+		
+		// check whether we can perform a simple cut without transcoding
+		if (cutDetails.frames.leftPos == cutDetails.frames.rightPos) {
+			console.log('Performing a simple cut');
+			outputBuffers.writeFile(outputFile, function (error) {
+				callback(error);
+			});
+			return;
+		}
+
+		// extract the section bounded by the two iframes
+		var boundedSection = buildTsBuffers(inputBuffers, cutDetails.frames.leftPos, cutDetails.frames.rightPos);
+		inputBuffers = null;		// no longer need the full input buffers
+		
+		// clip the bounded section with ffmpeg
+		var cutOffsetSec = (cutOffset - cutDetails.frames.leftOffset) / 90000;
+		clipWithFfmpeg(ffmpegBin, ffprobeBin, boundedSection, cutOffsetSec, leftPortion, function (error, clippedBuffers, clippedFramesInfo) {		
+		
+			if (error) {
+				callback(error);
+				return;
+			}
+
+			// fix the timestamps of the clip
+			nativeCutter.fixTimestamps(
+				clippedBuffers.buffers[0], 
+				clippedFramesInfo, 
+				cutDetails.timestamps, 
+				leftPortion);
+			
+			// add the clip to the output buffers and fix the continuity counters
+			if (leftPortion) {
+				outputBuffers = outputBuffers.concat(clippedBuffers);
+				
+				nativeCutter.fixContinuityForward(outputBuffers.buffers);
+			}
+			else {
+				outputBuffers = clippedBuffers.concat(outputBuffers);
+				
+				nativeCutter.fixContinuityBackward(outputBuffers.buffers);
+			}
+			
+			// write the result
+			outputBuffers.writeFile(outputFile, function (error) {
+				callback(error);
+			});
+		});
+	});
+}
+
+/* 
+	Sample command line:
+	
+	node TsCutter.js /tmp/testJsCutter.ts /web/content/shared/bin/ffmpeg-2.1-bin/ffmpeg-2.1.sh /web/content/shared/bin/ffmpeg-2.1-bin/ffprobe-2.1.sh 1085300 left /tmp/pre-1-4fd291d9968ec0fa2db44c52786295e0.ts /tmp/pre-2-cb11685b4a167e4a41d323871819a6df.ts /tmp/pre-3-5634dbf4fd82448ea3faf2b201820718.ts
+*/
+if(require.main === module) { 
+	if (process.argv.length < 8) {
+		console.log('Usage:\n\tnode TsCutter.js <output file> <ffmpeg bin> <ffprobe bin> <cut offset> <left/right> <file1> [<file2> [ ... ] ]');
+		process.exit(1);
+	}
+
+	var outputFile = process.argv[2];
+	var ffmpegBin = process.argv[3];
+	var ffprobeBin = process.argv[4];
+	var cutOffset = parseInt(process.argv[5]);
+	if (typeof cutOffset === 'undefined') {
+		console.log('Failed to parse cut offset ' + process.argv[5]);
+		process.exit(1);
+	}
+	
+	var leftPortion;
+	if (process.argv[6] == 'left') {
+		leftPortion = true;
+	}
+	else if (process.argv[6] == 'right') {
+		leftPortion = false;
+	}
+	else {
+		console.log('Invalid portion requested ' + process.argv[6] + ', should be either left or right');
+		process.exit(1);
+	}
+	var inputFiles = process.argv.slice(7);
+
+	cutTsFiles(outputFile, ffmpegBin, ffprobeBin, cutOffset, leftPortion, inputFiles, function (error) {
+		if (error) {
+			console.log(error);
+			process.exit(1);
+		}
+		console.log('Finished successfully');
+		process.exit(0);
+	});
+}
+else {
+	module.exports.cutTsFiles = cutTsFiles;
+}

--- a/native/node_addons/TsCutter/binding.gyp
+++ b/native/node_addons/TsCutter/binding.gyp
@@ -1,0 +1,12 @@
+{
+  "targets": [
+    {
+      "target_name": "TsCutter",
+      "sources": [ "TsCutter.cc", "ts_cutter_impl.c", "../../common/src/ffprobe.c", "../../common/src/dynamicBuffer.c", "../../common/src/mpegTs.c" ],
+      'include_dirs': [
+        "<!(node -p -e \"require('path').relative('.', require('path').dirname(require.resolve('nan')))\")",
+        "../../common/include"
+      ]
+    }
+  ]
+}

--- a/native/node_addons/TsCutter/ts_cutter_impl.c
+++ b/native/node_addons/TsCutter/ts_cutter_impl.c
@@ -1,0 +1,442 @@
+#include <string.h>
+#include "ts_cutter_impl.h"
+
+#define CLIPPING_DURATION_THRESHOLD 6000		// 2 frames in 30 fps
+
+byte_t* get_buffer_pos(
+	dynamic_buffer_t* source_bufs,
+	int source_buf_count,
+	int position)
+{
+	dynamic_buffer_t* source_bufs_end = source_bufs + source_buf_count;
+	dynamic_buffer_t* cur_buf;
+	int cur_pos = 0;
+	
+	for (cur_buf = source_bufs; cur_buf < source_bufs_end; cur_pos += cur_buf->write_pos, cur_buf++)
+	{
+		if (position >= cur_pos && position < cur_pos + cur_buf->write_pos)
+		{
+			return cur_buf->data + position - cur_pos;
+		}
+	}
+	return NULL;
+}
+
+void calc_duration_before(frame_info_t* frames, int frame_count)
+{
+	frame_info_t* frames_end = frames + frame_count;
+	frame_info_t* cur_frame;
+	int durations[MEDIA_TYPE_COUNT] = { 0 };
+	int *cur_duration;
+	
+	for (cur_frame = frames; cur_frame < frames_end; cur_frame++)
+	{
+		cur_duration = durations + cur_frame->media_type;
+		cur_frame->relative_duration = *cur_duration;
+		*cur_duration += cur_frame->duration;
+	}
+}
+
+void calc_duration_after(frame_info_t* frames, int frame_count)
+{
+	frame_info_t* cur_frame;
+	int durations[MEDIA_TYPE_COUNT] = { 0 };
+	int *cur_duration;
+	
+	for (cur_frame = frames + frame_count - 1; cur_frame >= frames; cur_frame--)
+	{
+		cur_duration = durations + cur_frame->media_type;
+		*cur_duration -= cur_frame->duration;
+		cur_frame->relative_duration = *cur_duration;
+	}
+}
+
+void has_video_audio_frames(frame_info_t* frames, int frame_count, bool_t* has_video, bool_t* has_audio)
+{
+	frame_info_t* frames_end = frames + frame_count;
+	frame_info_t* cur_frame;
+	
+	*has_video = FALSE;
+	*has_audio = FALSE;
+	
+	for (cur_frame = frames; cur_frame < frames_end; cur_frame++)
+	{
+		if (cur_frame->media_type == MEDIA_TYPE_VIDEO)
+		{
+			*has_video = TRUE;
+		}
+		else
+		{
+			*has_audio = TRUE;
+		}
+		
+		if (*has_video && *has_audio)
+			break;
+	}
+}
+
+void get_frame_timestamps(const byte_t* packet_offset, timestamps_t* timestamps)
+{
+	timestamp_offsets_t timestamp_offsets;
+	
+	get_timestamp_offsets(packet_offset, &timestamp_offsets);
+	get_timestamps(packet_offset, &timestamp_offsets, timestamps);
+}
+
+void set_frame_timestamps(byte_t* packet_offset, timestamps_t* timestamps, int timestamp_offset)
+{
+	timestamp_offsets_t timestamp_offsets;
+	
+	get_timestamp_offsets(packet_offset, &timestamp_offsets);
+	update_timestamps(packet_offset, &timestamp_offsets, timestamps, timestamp_offset);
+}
+
+void get_reference_timestamps(
+	dynamic_buffer_t* source_bufs,
+	int source_buf_count,
+	frame_info_t* source_frames, 
+	int source_frame_count,
+	bool_t left_portion, 
+	timestamps_t* result)
+{
+	timestamps_t cur_timestamps;
+	timestamps_t* cur_offsets;
+	frame_info_t* source_frames_end;
+	frame_info_t* cur_frame;
+	byte_t* cur_packet;
+		
+	reset_timestamps(&result[MEDIA_TYPE_VIDEO]);
+	reset_timestamps(&result[MEDIA_TYPE_AUDIO]);
+	
+	if (left_portion)
+	{
+		calc_duration_before(source_frames, source_frame_count);
+	}
+	else
+	{
+		calc_duration_after(source_frames, source_frame_count);
+	}
+
+	source_frames_end = source_frames + source_frame_count;
+	for (cur_frame = source_frames; cur_frame < source_frames_end; cur_frame++)
+	{
+		cur_offsets = result + cur_frame->media_type;
+		
+		cur_packet = get_buffer_pos(source_bufs, source_buf_count, cur_frame->pos);
+		if (cur_packet == NULL)
+		{
+			continue;
+		}
+		
+		get_frame_timestamps(cur_packet, &cur_timestamps);
+		
+		if (cur_timestamps.pcr != NO_TIMESTAMP)
+			cur_offsets->pcr = cur_timestamps.pcr - cur_frame->relative_duration;
+
+		if (cur_timestamps.pts != NO_TIMESTAMP)
+			cur_offsets->pts = cur_timestamps.pts - cur_frame->relative_duration;
+
+		if (cur_timestamps.dts != NO_TIMESTAMP)
+			cur_offsets->dts = cur_timestamps.dts - cur_frame->relative_duration;
+	}
+	
+	// if dts offset was not found, use pts offset
+	if (result[MEDIA_TYPE_VIDEO].dts == NO_TIMESTAMP)
+		result[MEDIA_TYPE_VIDEO].dts = result[MEDIA_TYPE_VIDEO].pts;
+
+	if (result[MEDIA_TYPE_AUDIO].dts == NO_TIMESTAMP)
+		result[MEDIA_TYPE_AUDIO].dts = result[MEDIA_TYPE_AUDIO].pts;
+}
+
+bool_t get_bounding_iframes(
+	dynamic_buffer_t* source_bufs,
+	int source_buf_count,
+	frame_info_t* frames, 
+	int frame_count, 
+	bool_t is_video, 
+	int cut_offset, 
+	bounding_iframes_t* result)
+{
+	frame_info_t* frames_end = frames + frame_count;
+	frame_info_t* cur_frame;
+	byte_t* cur_packet;
+	int frame_offset = 0;
+
+	memset(result, 0, sizeof(*result));
+	
+	for (cur_frame = frames; cur_frame < frames_end; cur_frame++)
+	{
+		// ignore audio frames in a video TS file
+		if (is_video && cur_frame->media_type != MEDIA_TYPE_VIDEO)
+		{
+			continue;
+		}
+		
+		// we care only about iframes
+		if (!cur_frame->is_iframe)
+		{
+			frame_offset += cur_frame->duration;
+			continue;
+		}
+
+		// make sure the iframe has a PCR timestamp
+		cur_packet = get_buffer_pos(source_bufs, source_buf_count, cur_frame->pos);
+		if (cur_packet == NULL || !frame_has_pcr(cur_packet))
+		{
+			frame_offset += cur_frame->duration;
+			continue;
+		}
+		
+			
+		if (frame_offset < cut_offset)
+		{
+			// iframe is before cut_offset, use as left frame (override any previously found frame)
+			result->left_iframe = cur_frame;
+			result->left_iframe_offset = frame_offset;
+			
+			// if frame is close enough to the cut position use it also as right frame
+			if (cut_offset - frame_offset < CLIPPING_DURATION_THRESHOLD)
+			{
+				break;
+			}
+		}
+		else
+		{
+			// iframe is after cut_offset, use as right frame
+			result->right_iframe = cur_frame;
+			result->right_iframe_offset = frame_offset;
+			break;
+		}
+		frame_offset += cur_frame->duration;
+	}
+
+	// if no frame was found return error
+	if (result->left_iframe == NULL && result->right_iframe == NULL)
+	{
+		return FALSE;
+	}
+	
+	// use the left frame if the right frame was not found
+	if (result->right_iframe == NULL)
+	{
+		result->right_iframe = result->left_iframe;
+		result->right_iframe_offset = result->left_iframe_offset;
+	}
+
+	// use the right frame if no left frame was found / right frame is close enough to the cut position
+	if (result->left_iframe == NULL || result->right_iframe_offset - cut_offset < CLIPPING_DURATION_THRESHOLD)
+	{
+		result->left_iframe = result->right_iframe;
+		result->left_iframe_offset = result->right_iframe_offset;
+	}
+		
+	return TRUE;
+}
+
+bool_t get_cut_details(
+	dynamic_buffer_t* source_bufs,
+	int source_buf_count,
+	char* frames_text,
+	int frames_text_size,
+	int cut_offset,
+	bool_t left_portion, 
+	bounding_iframes_t* bounding_iframes, 
+	timestamps_t* reference_timestamps)
+{
+	frame_info_t* source_frames;
+	int source_frame_count;	
+	bool_t has_video;
+	bool_t has_audio;
+
+	// parse frames text buffer
+	source_frames = parse_ffprobe_output(frames_text, frames_text_size, &source_frame_count);
+	if (source_frames == NULL)
+	{
+		return FALSE;
+	}
+
+	// check whether we have audio/video
+	has_video_audio_frames(source_frames, source_frame_count, &has_video, &has_audio);
+
+	if (!get_bounding_iframes(
+		source_bufs,
+		source_buf_count,
+		source_frames,
+		source_frame_count,
+		has_video,
+		cut_offset,
+		bounding_iframes))
+	{
+		return FALSE;
+	}
+
+	get_reference_timestamps(
+		source_bufs,
+		source_buf_count,
+		bounding_iframes->left_iframe, 
+		bounding_iframes->right_iframe - bounding_iframes->left_iframe, 
+		left_portion, 
+		reference_timestamps);
+	
+	return TRUE;
+}
+
+bool_t fix_timestamps(
+	byte_t* source_buf,
+	size_t source_size,
+	char* frames_text,
+	int frames_text_size,
+	timestamps_t* reference_timestamps,
+	bool_t left_portion)
+{
+	frame_info_t* cur_frame;
+	frame_info_t* source_frames;
+	frame_info_t* source_frames_end;
+	timestamps_t* cur_offsets;
+	int source_frame_count;	
+
+	source_frames = parse_ffprobe_output(frames_text, frames_text_size, &source_frame_count);
+	if (source_frames == NULL)
+	{
+		return FALSE;
+	}
+
+	if (left_portion)
+	{
+		calc_duration_before(source_frames, source_frame_count);
+	}
+	else
+	{
+		calc_duration_after(source_frames, source_frame_count);
+	}
+	
+	source_frames_end = source_frames + source_frame_count;
+	for (cur_frame = source_frames; cur_frame < source_frames_end; cur_frame++)
+	{
+		cur_offsets = reference_timestamps + cur_frame->media_type;
+		set_frame_timestamps(source_buf + cur_frame->pos, cur_offsets, cur_frame->relative_duration);
+	}
+
+	return TRUE;
+}
+
+bool_t find_last_pat_pmt_packets(byte_t* data, int size, byte_t** last_pat_packet, byte_t** last_pmt_packet)
+{
+	byte_t* end_data = data + size - TS_PACKET_LENGTH;
+	byte_t* packet_offset;
+	byte_t* cur_data;
+	int cur_pid;
+	int pmt_program_pid = 0;
+	const mpeg_ts_header_t* ts_header;
+	const mpeg_ts_adaptation_field_t* adapt_field;
+	const pat_t* pat_header;
+	const pat_entry_t* pat_entry;
+	int pat_entry_count;
+	int i;
+	
+	*last_pat_packet = NULL;
+	*last_pmt_packet = NULL;
+
+	for (cur_data = data; cur_data <= end_data; cur_data += TS_PACKET_LENGTH)
+	{
+		// extract the current PID
+		ts_header = (const mpeg_ts_header_t*)cur_data;				
+		cur_pid = mpeg_ts_header_get_PID(ts_header);
+		
+		if (cur_pid == PAT_PID)
+		{
+			*last_pat_packet = cur_data;
+
+			// skip the adapation field if present
+			packet_offset = cur_data + sizeof_mpeg_ts_header;
+			if (mpeg_ts_header_get_adaptationFieldExist(ts_header))
+			{
+				adapt_field = (const mpeg_ts_adaptation_field_t*)packet_offset;
+				packet_offset += 1 + mpeg_ts_adaptation_field_get_adaptationFieldLength(adapt_field);
+			}
+			
+			// extract the pat header
+			pat_header = (const pat_t*)packet_offset;
+			packet_offset += sizeof_pat;
+			pat_entry_count = (pat_get_sectionLength(pat_header) - 9) / sizeof_pat_entry;
+			for (i = 0; i < pat_entry_count; i++)
+			{
+				// extract the pat entry
+				pat_entry = (const pat_entry_t*)packet_offset;
+				packet_offset += sizeof_pat_entry;
+				
+				// if the program number is 1, the PID is PID of the PMT
+				if (pat_entry_get_programNumber(pat_entry) == 1)
+					pmt_program_pid = pat_entry_get_programPID(pat_entry);
+			}
+		}
+		else if (cur_pid == pmt_program_pid)
+		{
+			*last_pmt_packet = cur_data;
+		}
+	}
+	
+	return (*last_pat_packet != NULL) && (*last_pmt_packet != NULL);
+}
+
+void fix_continuity_forward(dynamic_buffer_t* segments, int segment_count)
+{
+	byte_t continuity_values[0x2000];		// last seen continuity counter per PID
+	byte_t* cur_counter;
+	byte_t* cur_pos;
+	byte_t* end_pos;
+	int cur_value;
+	dynamic_buffer_t* cur_segment;
+	dynamic_buffer_t* segments_end;
+	
+	memset(continuity_values, 0xff, sizeof(continuity_values));
+
+	segments_end = segments + segment_count;
+	for (cur_segment = segments; cur_segment < segments_end; cur_segment++)
+	{
+		end_pos = cur_segment->data + cur_segment->write_pos;
+		for (cur_pos = cur_segment->data; cur_pos < end_pos; cur_pos += TS_PACKET_LENGTH)
+		{
+			cur_counter = continuity_values + mpeg_ts_header_get_PID(cur_pos);
+			if (*cur_counter != 0xff)
+			{
+				cur_value = (*cur_counter + 1) & 0x0f;
+				mpeg_ts_header_set_continuityCounter(cur_pos, cur_value);
+			}
+			else
+				cur_value = mpeg_ts_header_get_continuityCounter(cur_pos);
+			
+			*cur_counter = cur_value;			
+		}
+	}
+}
+
+void fix_continuity_backward(dynamic_buffer_t* segments, int segment_count)
+{
+	byte_t continuity_values[0x2000];
+	byte_t* cur_counter;
+	byte_t* cur_pos;
+	byte_t* end_pos;
+	int cur_value;
+	dynamic_buffer_t* cur_segment;
+	
+	memset(continuity_values, 0xff, sizeof(continuity_values));
+
+	for (cur_segment = segments + segment_count - 1; cur_segment >= segments; cur_segment--)
+	{
+		end_pos = cur_segment->data;
+		for (cur_pos = cur_segment->data + cur_segment->write_pos - TS_PACKET_LENGTH; cur_pos >= end_pos; cur_pos -= TS_PACKET_LENGTH)
+		{
+			cur_counter = continuity_values + mpeg_ts_header_get_PID(cur_pos);
+			if (*cur_counter != 0xff)
+			{
+				cur_value = (*cur_counter - 1) & 0x0f;
+				mpeg_ts_header_set_continuityCounter(cur_pos, cur_value);
+			}
+			else
+				cur_value = mpeg_ts_header_get_continuityCounter(cur_pos);
+			
+			*cur_counter = cur_value;			
+		}
+	}
+}

--- a/native/node_addons/TsCutter/ts_cutter_impl.h
+++ b/native/node_addons/TsCutter/ts_cutter_impl.h
@@ -1,0 +1,47 @@
+#ifndef __TS_CUTTER_IMPL_H__
+#define __TS_CUTTER_IMPL_H__
+
+#include "dynamicBuffer.h"
+#include "ffprobe.h"
+#include "mpegTs.h"
+
+typedef struct {
+	frame_info_t* left_iframe;
+	frame_info_t* right_iframe;
+	int left_iframe_offset;
+	int right_iframe_offset;	
+} bounding_iframes_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+bool_t get_cut_details(
+	dynamic_buffer_t* source_bufs,
+	int source_buf_count,
+	char* frames_text,
+	int frames_text_size,
+	int cut_offset,
+	bool_t left_portion, 
+	bounding_iframes_t* bounding_iframes, 
+	timestamps_t* reference_timestamps);
+
+bool_t fix_timestamps(
+	byte_t* source_buf,
+	size_t source_size,
+	char* frames_text,
+	int frames_text_size,
+	timestamps_t* reference_timestamps,
+	bool_t left_portion);
+
+bool_t find_last_pat_pmt_packets(byte_t* data, int size, byte_t** last_pat_packet, byte_t** last_pmt_packet);
+	
+void fix_continuity_forward(dynamic_buffer_t* segments, int segment_count);
+
+void fix_continuity_backward(dynamic_buffer_t* segments, int segment_count);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif // __TS_CUTTER_IMPL_H__

--- a/poc/node/KalturaFfmpegParams.js
+++ b/poc/node/KalturaFfmpegParams.js
@@ -1,0 +1,260 @@
+var KalturaFfmpegParams = {
+
+	/**
+	 * Select closest bitrate from know list of bitrates
+	 * 
+	 * @param bitrate
+	 * @param standardBitrates
+	 * @returns int
+	 */
+	normalizeBitrate: function(bitrate, standardBitrates){
+		var normBitrate = standardBitrates[0];
+		for(var i = 1; i < standardBitrates.length; i++){
+			var curBitrate = standardBitrates[i];
+			if(Math.abs(curBitrate - bitrate) < Math.abs(normBitrate - bitrate)){
+				normBitrate = curBitrate;
+			}
+		}
+		
+		return normBitrate;
+	},
+
+	
+	/**
+	 * Select closest bitrate from know list of video bitrates
+	 * 
+	 * @param bitrate
+	 * @returns int
+	 */
+	normalizeVideoBitrate: function(bitrate){
+		return this.normalizeBitrate(bitrate, [300,400,500,700,900,1200,1600,2000,2500,3000,4000]);
+	},
+
+
+	/**
+	 * Select closest bitrate from know list of audio bitrates
+	 * 
+	 * @param bitrate
+	 * @returns int
+	 */
+	normalizeAudioBitrate: function(bitrate){
+		return this.normalizeBitrate(bitrate, [64,128]);
+	},
+
+	///////////// MISC /////////////
+
+	getParamDuration: function (duration) {
+		return ' -t ' + duration;
+	},
+	
+	getParamContainerMpegTs: function (mediaInfo) {
+		return ' -f mpegts';
+	},	
+	
+	///////////// VIDEO /////////////
+
+	getParamVideoNone: function (mediaInfo) {
+		return ' -vn';
+	},
+	
+	getParamVideoCopy: function (mediaInfo) {
+		return ' -vcodec copy';
+	},
+
+	getParamVideoH264Base: function (mediaInfo) {
+		return	' -vcodec libx264 -subq 7 -qcomp 0.6 -qmin 10 -qmax 50 -qdiff 4 -bf 0' +
+				' -coder 1 -x264opts b-pyramid:weightb:mixed-refs:8x8dct:no-fast-pskip=0:force-cfr' + 
+				' -pix_fmt yuv420p -threads 4';
+	},
+	
+	getParamVideoFilter: function (mediaInfo) {
+		return ' -bsf h264_mp4toannexb';
+	},
+	
+	getParamVideoBlackInput: function (mediaInfo) {
+		return ' -f rawvideo -pix_fmt rgb24 -i /dev/zero';
+	},
+	
+	getParamVideoProfile: function (mediaInfo) {
+		if(mediaInfo.video.profile){
+			var validProfiles = ['baseline', 'main', 'high', 'high10', 'high422', 'high444'];
+			var profileName = mediaInfo.video.profile.name.toLowerCase();
+			if (validProfiles.indexOf(profileName) >= 0) {
+				return ' -vprofile ' + profileName + ' -level ' + mediaInfo.video.profile.level;
+			}
+		}
+		return ' -vprofile main -level 3.1';
+	},
+	
+	getParamVideoBitrate: function (mediaInfo) {
+		if(mediaInfo.video.bitrate){
+			return ' -b:v ' + this.normalizeVideoBitrate(mediaInfo.video.bitrate / 1024) + 'k';
+		}
+		else if(mediaInfo.general.bitrate){
+			return ' -b:v ' + this.normalizeVideoBitrate(mediaInfo.general.bitrate / 1024) + 'k';
+		}
+		else if(mediaInfo.video.duration){
+			return ' -b:v ' + this.normalizeVideoBitrate(mediaInfo.fileSize * 8 / mediaInfo.video.duration / 1024) + 'k';
+		}
+		return '';
+	},
+	
+	getParamVideoScale: function (mediaInfo) {
+		if(mediaInfo.video.width && mediaInfo.video.height){
+			var result = ' -vf scale="iw*min(' + mediaInfo.video.width + '/iw\\,' + mediaInfo.video.height + '/ih):';
+			result += 'ih*min(' + mediaInfo.video.width + '/iw\\,' + mediaInfo.video.height + '/ih),';
+			result += 'pad=' + mediaInfo.video.width + ':' + mediaInfo.video.height + ':';
+			result += '(' + mediaInfo.video.width + '-iw)/2:(' + mediaInfo.video.height + '-ih)/2"';
+			return result;
+		}
+		return '';
+	},
+	
+	getParamVideoFixedSize: function (mediaInfo) {
+		if(mediaInfo.video.width && mediaInfo.video.height){
+			return ' -s ' + mediaInfo.video.width + 'x' + mediaInfo.video.height;
+		}
+		return '';
+	},
+	
+	getParamVideoFrameRate: function (mediaInfo) {
+		if(mediaInfo.video.frameRate){
+			return ' -r ' + mediaInfo.video.frameRate;
+		}
+		return '';
+	},
+	
+	getParamVideoReframes: function (mediaInfo) {
+		if(mediaInfo.video.reframes){
+			return ' -refs ' + mediaInfo.video.reframes;
+		}
+		return ' -refs 6';
+	},
+
+	///////////// AUDIO /////////////
+	
+	getParamAudioNone: function (mediaInfo) {
+		return ' -an';
+	},
+
+	getParamAudioCopy: function (mediaInfo) {
+		return ' -acodec copy';
+	},
+	
+	getParamAudioAacBase: function (mediaInfo) {
+		return ' -acodec libfdk_aac';
+	},
+	
+	getParamAudioSilenceInput: function (mediaInfo) {
+		return ' -f s16le -acodec pcm_s16le -i /dev/zero';
+	},
+	
+	getParamAudioProfile: function (mediaInfo) {
+		var profileMapping = {
+			'LC': 'aac_low',
+			'HE-AAC': 'aac_he',
+			'HE-AACv2': 'aac_he_v2',
+			'ER AAC LD': 'aac_ld',
+			'ER AAC ELD': 'aac_eld',
+		}
+		if (mediaInfo.audio.profile && profileMapping[mediaInfo.audio.profile]) {
+			return ' -profile:a ' + profileMapping[mediaInfo.audio.profile];
+		}
+		return ' -profile:a aac_he';
+	},
+	
+	getParamAudioBitrate: function (mediaInfo) {
+		if(mediaInfo.audio.bitrate){
+			return ' -b:a ' + this.normalizeAudioBitrate(mediaInfo.audio.bitrate / 1024) + 'k';
+		}
+		return '';
+	},
+	
+	getParamAudioSampleRate: function (mediaInfo) {
+		if(mediaInfo.audio.sampleRate){
+			return ' -ar ' + mediaInfo.audio.sampleRate;
+		}
+		return '';
+	},
+	
+	getParamAudioChannels: function (mediaInfo) {
+		if(mediaInfo.audio.channels){
+			return ' -ac ' + mediaInfo.audio.channels;
+		}
+		return '';
+	},
+	
+	buildEncodingParams: function(mediaInfo, copyVideo, copyAudio){
+		var result = '';
+
+		if(mediaInfo.video){
+			if (!copyVideo) {
+				result += 
+					this.getParamVideoH264Base(mediaInfo) + 
+					this.getParamVideoProfile(mediaInfo) + 
+					this.getParamVideoBitrate(mediaInfo) + 
+					this.getParamVideoScale(mediaInfo) + 						 
+					this.getParamVideoFrameRate(mediaInfo) + 
+					this.getParamVideoReframes(mediaInfo);
+			}
+			else {
+				result += this.getParamVideoCopy(mediaInfo);
+			}
+		}
+		else{
+			result += this.getParamVideoNone(mediaInfo);
+		}
+			
+		// audio codec
+		if(mediaInfo.audio){
+			if (!copyAudio) {
+				result += 
+					this.getParamAudioAacBase(mediaInfo) +
+					this.getParamAudioProfile(mediaInfo) +
+					this.getParamAudioBitrate(mediaInfo) +
+					this.getParamAudioSampleRate(mediaInfo) +
+					this.getParamAudioChannels(mediaInfo);
+			} 
+			else {
+				result += this.getParamAudioCopy(mediaInfo);
+			}
+		}
+		else{
+			result += this.getParamAudioNone(mediaInfo);
+		}
+
+		if(mediaInfo.video && !copyVideo) {
+			result += this.getParamVideoFilter(mediaInfo);
+		}
+		
+		result += this.getParamContainerMpegTs(mediaInfo);
+		
+		return result;
+	},
+	
+	buildBlackInputParams: function(mediaInfo, blackDuration){
+		var result = '';
+		
+		// video codec
+		if(mediaInfo.video){
+			result += 
+				this.getParamDuration(blackDuration) + 
+				this.getParamVideoFixedScale(mediaInfo) + 
+				this.getParamVideoFrameRate(mediaInfo) + 
+				this.getParamVideoBlackInput(mediaInfo);
+		}
+			
+		// audio codec
+		if(mediaInfo.audio){
+			result = 
+				this.getParamDuration(blackDuration) + 
+				this.getParamAudioSampleRate(mediaInfo) +
+				this.getParamAudioChannels(mediaInfo) +
+				this.getParamAudioSilenceInput(mediaInfo);
+		}
+		
+		return result;
+	},
+};
+
+module.exports = KalturaFfmpegParams;

--- a/poc/node/KalturaMediaInfo.js
+++ b/poc/node/KalturaMediaInfo.js
@@ -1,0 +1,233 @@
+var child_process = require('child_process');
+var fs = require('fs');
+
+var KalturaMediaInfo = {
+	bin: 'mediainfo',
+
+	config: {
+		general: {
+			bitrate: {
+				names: ['overall bit rate'],
+				callback: function(value){
+					return KalturaMediaInfo.parseBitrate(value);
+				}
+			}
+		},
+		video: {
+			duration: {
+				names: ['duration'],
+				callback: function(value){
+					return KalturaMediaInfo.parseDuration(value);
+				}
+			},
+			bitrate: {
+				names: ['bit rate'],
+				callback: function(value){
+					return KalturaMediaInfo.parseBitrate(value);
+				}
+			},
+			width: {
+				names: ['width'],
+				callback: function(value){
+					return KalturaMediaInfo.parseItem(value, ['pixels']);
+				}
+			},
+			height: {
+				names: ['height'],
+				callback: function(value){
+					return KalturaMediaInfo.parseItem(value, ['pixels']);
+				}
+			},
+			frameRate: {
+				names: ['frame rate'],
+				callback: function(value){
+					return KalturaMediaInfo.parseItem(value, ['fps']);
+				}
+			},
+			reframes: {
+				names: ['format settings, reframes'],
+				callback: function(value){
+					return KalturaMediaInfo.parseItem(value, ['frame', 'frames']);
+				}
+			},
+			profile: {
+				names: ['format profile'],
+				callback: function(value){
+					return KalturaMediaInfo.parseVideoProfile(value);
+				}
+			}
+		},
+		audio: {
+			bitrate: {
+				names: ['bit rate'],
+				callback: function(value){
+					return KalturaMediaInfo.parseBitrate(value);
+				}
+			},
+			sampleRate: {
+				names: ['sampling rate'],
+				callback: function(value){
+					return KalturaMediaInfo.parseItem(value, ['khz']) * 1000;
+				}
+			},
+			channels: {
+				names: ['channel(s)'],
+				callback: function(value){
+					return KalturaMediaInfo.parseItem(value, ['channel', 'channels']);
+				}
+			},
+			profile: {
+				names: ['format profile'],
+				callback: function(value){
+					return KalturaMediaInfo.parseAudioProfile(value);
+				}
+			},
+		}		
+	},
+	
+	parseRaw: function(data, callback){
+		var sectionName = null;
+		var lines = data.split('\n');
+		var parsedAttributes = {};
+		for(var i = 0; i < lines.length; i++){
+			var line = lines[i].trim();
+			
+			if(!line.length){
+				sectionName = null;
+				continue;
+			}
+			
+			var parts = line.split(':');
+			if(parts.length == 1){
+				sectionName = line.toLowerCase();
+				parsedAttributes[sectionName] = {};
+				continue;
+			}
+
+			var key = parts[0].trim().toLowerCase();
+			var value = parts[1].trim();
+			parsedAttributes[sectionName][key] = value;
+		}
+		
+		var mediaInfo = {};
+		
+		for(sectionName in KalturaMediaInfo.config){
+			if(!parsedAttributes[sectionName]){
+				continue;
+			}
+			
+			mediaInfo[sectionName] = {};
+			var section = KalturaMediaInfo.config[sectionName];
+			for(var configAttributeName in section){
+				if(!section[configAttributeName]){
+					continue;
+				}
+				var attribute = section[configAttributeName];
+				for(var i = 0; i < attribute.names.length; i++){
+					var attributeName = attribute.names[i];
+					if(typeof parsedAttributes[sectionName][attributeName] === 'undefined'){
+						continue;
+					}
+					
+					var value = parsedAttributes[sectionName][attributeName];
+					mediaInfo[sectionName][configAttributeName] = attribute.callback(value);
+				}
+			}
+		}
+		
+		return mediaInfo;
+	},
+	
+	parse: function(filePath, callback){
+		var This = this;
+		fs.stat(filePath, function (err, stats) {
+			// TODO handle errors
+			
+			var fileSize = stats["size"];
+			var cmd = This.bin + ' ' + filePath;
+			child_process.exec(cmd, function (error, stdout, stderr) {
+				var mediaInfo = KalturaMediaInfo.parseRaw(stdout);
+				mediaInfo.fileSize = fileSize;
+				callback(mediaInfo);
+			});
+		});
+	},
+	
+	parseValue: function(value){
+		value = value.split(' / ')[0];			// support values like 'Sampling rate : 44.1 KHz / 22.05 KHz'
+		var splittedValue = value.split(' ');
+		
+		return {
+			units: splittedValue.pop().toLowerCase(),
+			value: parseFloat(splittedValue.join(''))
+		};
+	},
+	
+	parseDuration: function(value){
+		var units = {
+			'ms': 	0.001,
+			's': 	1,
+			'mn': 	60,
+			'h': 	60 * 60,
+		}
+		var splittedValue = value.split(' ');
+		var result = 0;
+		
+		for (var i = 0; i < splittedValue.length; i++) {
+			var curValue = splittedValue[i].trim();
+			if (!curValue) {
+				continue;
+			}
+			for (var curUnit in units) {
+				if (!curValue.endsWith(curUnit)) {
+					continue;
+				}
+				curValue = curValue.slice(0, curValue.length - curUnit.length);
+				result += parseFloat(curValue) * units[curUnit];
+				break;
+			}
+		}
+		return result;
+	},
+	
+	parseBitrate: function(value){
+		var parsedValue = this.parseValue(value);
+		switch(parsedValue.units){
+			case 'bps':
+				return parsedValue.value;
+			case 'kbps':
+				return parsedValue.value * 1024;
+			case 'mbps':
+				return parsedValue.value * 1024 * 1024;
+			case 'gbps':
+				return parsedValue.value * 1024 * 1024 * 1024;
+		}
+		return null;
+	},
+	
+	parseVideoProfile: function(value){
+		var splittedValue = value.split('@L');
+		if(splittedValue.length != 2)
+			return null;
+		
+		return {
+			name: splittedValue[0],
+			level: splittedValue[1]
+		};
+	},
+
+	parseAudioProfile: function(value){
+		return value.split(' / ')[0].split('@')[0];
+	},
+	
+	parseItem: function(value, allowedUnits){
+		var parsedValue = this.parseValue(value);
+		for(var i = 0; i < allowedUnits.length; i++){
+			if(parsedValue.units == allowedUnits[i]){
+				return parsedValue.value;
+			}
+		}
+	}
+};
+
+module.exports = KalturaMediaInfo;

--- a/poc/tracker/streamTracker.py
+++ b/poc/tracker/streamTracker.py
@@ -14,7 +14,7 @@ import json
 import sys
 import os
 
-TS_CUTTER_PATH = os.path.join(os.path.dirname(__file__), '../../native/ts_cutter/ts_cutter')
+TS_CUTTER_PATH = 'node %s' % os.path.join(os.path.dirname(__file__), '../../native/node_addons/TsCutter/TsCutter.js')
 TS_PREPARER_PATH = os.path.join(os.path.dirname(__file__), '../../native/ts_preparer/ts_preparer')
 FFPROBE_PATH = '/web/content/shared/bin/ffmpeg-2.1-bin/ffprobe-2.1.sh'
 FFMPEG_PATH = '/web/content/shared/bin/ffmpeg-2.1-bin/ffmpeg-2.1.sh'
@@ -47,7 +47,7 @@ def md5(buf):
 def getUrl(url, fileExt):
 	path = os.path.join(tempDownloadPath, md5(url) + fileExt)
 	if not os.path.exists(path):
-		writeOutput("downloading %s" % (url))
+		writeOutput("downloading %s to %s" % (url, path))
 		startTime = time.time()
 		urllib.urlretrieve(url, path)
 		writeOutput("download took %s" % (time.time() - startTime))


### PR DESCRIPTION
when running ffmpeg to clip the video, we need to apply the same logic we
use to transcode an ad to the stream parameters (specifically, the problem
was with AAC audio profiles). in order to avoid the need to re-implement
this logic in native C, the ts_cutter was migrated to node.
all the parts that run per-frame/per-packet were implemented in 5 native
functions exposed as a node addon, all the wrapping logic was implemented
in JS.
