### PR TITLE
Add play-server https support + update deployment doc

### DIFF
--- a/config/config.ini.template
+++ b/config/config.ini.template
@@ -11,9 +11,12 @@ domain = @CLOUD_HOSTNAME@
 ; domainPort = 80
 internalDomain = @CLOUD_HOSTNAME@
 httpPort = 80
+;httpsPort = 443
 secret = @CLOUD_SECRET@
 sharedTempPath = @CLOUD_SHARED_TEMP_PATH@
 requestTimeout = 40
+;keyFilePath = @KEY_FILE_PATH@
+;certFilePath = @CERT_FILE_PATH@
 
 [logger]
 debugEnabled = 0

--- a/lib/KalturaServer.js
+++ b/lib/KalturaServer.js
@@ -6,6 +6,7 @@ var path = require('path');
 var mime = require('mime');
 var util = require('util');
 var http = require('http');
+var https = require('https');
 var cluster = require('cluster');
 var querystring = require('querystring');
 
@@ -16,14 +17,33 @@ var KalturaServer = function(){
 util.inherits(KalturaServer, kaltura.KalturaBase);
 
 KalturaServer.prototype.hostname = os.hostname();
-KalturaServer.prototype.webServer = null;
+KalturaServer.prototype.httpWebServer = null;
+KalturaServer.prototype.httpsWebServer = null;
+
+
 
 KalturaServer.prototype.init = function() {
-	this.startWebServer();
+	this.startWebServers();
 };
 
-KalturaServer.prototype.startWebServer = function() {
-    this.webServer = http.createServer();
+KalturaServer.prototype.startWebServers = function() {
+    this.httpWebServer = http.createServer();
+    
+    if(KalturaConfig.config.cloud.httpsPort){
+    	if(!KalturaConfig.config.cloud.keyFilePath || !KalturaConfig.config.cloud.certFilePath){
+    		KalturaLogger.log('Unable to locate keyFilePath || certFilePath in the configuration file. Https listener will not be created');
+    		return;
+    	}
+    	var keyFilePath = KalturaConfig.config.cloud.keyFilePath;
+    	var certFielPath = KalturaConfig.config.cloud.certFilePath;
+    	
+    	var options = {
+    			  key: fs.readFileSync(keyFilePath),
+    			  cert: fs.readFileSync(certFielPath)
+    	};
+        
+        this.httpsWebServer = https.createServer(options);
+    }
 };
 
 
@@ -169,14 +189,32 @@ var KalturaChildProcess = function(){
 util.inherits(KalturaChildProcess, KalturaServer);
 
 KalturaChildProcess.prototype.start = function(){
+	this.startHttpServer();
+	if(this.httpsWebServer){
+		this.startHttpsServer();
+	}
+};
+
+KalturaChildProcess.prototype.startHttpServer = function() {
 	var httpPort = KalturaConfig.config.cloud.httpPort;
 	KalturaLogger.log('Listening on port [' + httpPort + ']');
 	var This = this;
-	this.webServer.on('request', function(request, response) {
+	this.httpWebServer.on('request', function(request, response) {
 		return This.handleRequest(request, response);
 	});
-	this.webServer.listen(httpPort);
-};
+	this.httpWebServer.listen(httpPort);
+}
+
+KalturaChildProcess.prototype.startHttpsServer = function() {
+	var httpsPort = KalturaConfig.config.cloud.httpsPort;
+	
+	KalturaLogger.log('Listening on port [' + httpsPort + ']');
+	var This = this;
+	this.httpsWebServer.addListener('request', function(request, response) {
+		return This.handleRequest(request, response);
+	});
+	this.httpsWebServer.listen(httpsPort);
+}
 
 KalturaChildProcess.prototype.stop = function(){
 	for(var serviceName in this.managers){

--- a/play_server_deployment.md
+++ b/play_server_deployment.md
@@ -46,6 +46,7 @@ Replace tokens in ini files:
 - @CLOUD_SECRET@ - Random short string, e.g. 'abc'
 - @CLOUD_SHARED_TEMP_PATH@ - path to shared temp folder disc, e.g. /opt/kaltura/shared/tmp
 - @LOG_DIR@ - Path to logs folder, e.g. /opt/kaltura/log.
+- If you are not running with a production environment Wowza license update hackWowzaUniqueSession to 1   
 
 Execute:
 =======================


### PR DESCRIPTION
Important!!! To activate the https listener you need to:
1. Un-mark the following values from the configuration: httpsPort,
keyFilePath, certFilePath.
2. Update the above fields with your values
