### PR TITLE
Fix but in master manifest flow.

### DIFF
--- a/lib/managers/KalturaManifestManager.js
+++ b/lib/managers/KalturaManifestManager.js
@@ -367,6 +367,9 @@ KalturaManifestManager.prototype.master = function(request, response, params){
 			}
 		});
 	}
+	else{
+		doFetchMaster();
+	}
 };
 
 


### PR DESCRIPTION
If uiConfId was not provided on the master manifest request continue as
if the ad tracking is not required.
