### PR TITLE
Fix uiConf retrieval flow, add play server permission validation

### DIFF
--- a/lib/KalturaManager.js
+++ b/lib/KalturaManager.js
@@ -125,4 +125,47 @@ KalturaManager.prototype.restore = function(request, response, params){
 	response.end();
 };
 
+/**
+ * check if the play server feature is allowed for partner
+ * @param partner id
+ * @param permissonName
+ * @param callback
+ */
+KalturaManager.prototype.isPermissionAllowedForPartner = function(partnerId, permissonName, callback){
+	var This = this;
+	
+	var checkIfPermissionAllowed = function(){
+		filter = new kaltura.client.objects.KalturaPermissionFilter();
+		filter.nameEqual = permissonName;
+		
+		pager = new kaltura.client.objects.KalturaFilterPager();
+		pager.pageSize = 1;
+		
+		This.impersonate(partnerId);
+		This.client.permission.listAction(function(result) {
+			if(result.objectType == 'KalturaAPIException'){
+				KalturaLogger.error('Client [permission.list][' + result.code + ']: ' + result.message);
+				callback(false);
+			}
+			else{
+				if(result.totalCount && result.objects[0].name == permissonName){
+					callback(true);
+				}
+				else{
+					callback(false);
+				}	
+			}
+		}, filter, pager);
+	};
+	
+	if(This.client == null){
+		This.initClient(KalturaConfig.config.client, function(){
+			checkIfPermissionAllowed();
+		});
+	}
+	else{
+		checkIfPermissionAllowed();
+	}
+};
+
 module.exports.KalturaManager = KalturaManager;

--- a/lib/client/KalturaClient.js
+++ b/lib/client/KalturaClient.js
@@ -58,6 +58,11 @@ KalturaClient.prototype.baseEntry = null;
  */
 KalturaClient.prototype.liveStream = null;
 /**
+ * Permission service lets you create and manage user permissions
+ * @param kaltura.services.KalturaPermissionService
+ */
+KalturaClient.prototype.permission = null;
+/**
  * Session service
  *   
  * @param kaltura.services.KalturaSessionService
@@ -92,6 +97,7 @@ KalturaClient.prototype.init = function(config){
   //initialize client services:
   this.baseEntry = new kaltura.services.KalturaBaseEntryService(this);
   this.liveStream = new kaltura.services.KalturaLiveStreamService(this);
+  this.permission = new kaltura.services.KalturaPermissionService(this);
   this.session = new kaltura.services.KalturaSessionService(this);
   this.uiConf = new kaltura.services.KalturaUiConfService(this);
   this.metadata = new kaltura.services.KalturaMetadataService(this);

--- a/lib/client/KalturaServices.js
+++ b/lib/client/KalturaServices.js
@@ -114,6 +114,49 @@ KalturaLiveStreamService.prototype.createPeriodicSyncPoints = function(callback,
 };
 
 /**
+ *Class definition for the Kaltura service: permission.
+ * The available service actions:
+ * @action list Lists permission objects that are associated with an account.
+ * Blocked permissions are listed unless you use a filter to exclude them.
+ * Blocked permissions are listed unless you use a filter to exclude them.
+ */
+function KalturaPermissionService(client){
+        KalturaPermissionService.super_.call(this);
+        this.init(client);
+}
+
+util.inherits(KalturaPermissionService, kaltura.KalturaServiceBase);
+module.exports.KalturaPermissionService = KalturaPermissionService;
+
+/**
+ * Lists permission objects that are associated with an account.
+ * Blocked permissions are listed unless you use a filter to exclude them.
+ * Blocked permissions are listed unless you use a filter to exclude them.
+ * @param filter KalturaPermissionFilter A filter used to exclude specific types of permissions (optional, default: null).
+ * @param pager KalturaFilterPager A limit for the number of records to display on a page (optional, default: null).
+ * @return KalturaPermissionListResponse.
+ */
+KalturaPermissionService.prototype.listAction = function(callback, filter, pager){
+        if(!filter){
+                filter = null;
+        }
+        if(!pager){
+                pager = null;
+        }
+        var kparams = {};
+        if (filter !== null){
+                this.client.addParam(kparams, 'filter', kaltura.toParams(filter));
+        }
+        if (pager !== null){
+                this.client.addParam(kparams, 'pager', kaltura.toParams(pager));
+        }
+        this.client.queueServiceActionCall('permission', 'list', kparams);
+        if (!this.client.isMultiRequest()){
+                this.client.doQueue(callback);
+        }
+};
+
+/**
  *Class definition for the Kaltura service: session.
  * The available service actions:
  * @action  start  Start a session with Kaltura's server.

--- a/lib/client/KalturaVO.js
+++ b/lib/client/KalturaVO.js
@@ -652,6 +652,56 @@ util.inherits(KalturaMetadataListResponse, kaltura.KalturaObjectBase);
 
 
 /**
+ * @param id int  (readOnly).
+ * @param type int  (readOnly).
+ * @param name string .
+ * @param friendlyName string .
+ * @param description string .
+ * @param status int .
+ * @param partnerId int  (readOnly).
+ * @param dependsOnPermissionNames string .
+ * @param tags string .
+ * @param permissionItemsIds string .
+ * @param createdAt int  (readOnly).
+ * @param updatedAt int  (readOnly).
+ * @param partnerGroup string .
+ */
+function KalturaPermission(){
+        KalturaPermission.super_.call(this);
+        this.id = null;
+        this.type = null;
+        this.name = null;
+        this.friendlyName = null;
+        this.description = null;
+        this.status = null;
+        this.partnerId = null;
+        this.dependsOnPermissionNames = null;
+        this.tags = null;
+        this.permissionItemsIds = null;
+        this.createdAt = null;
+        this.updatedAt = null;
+        this.partnerGroup = null;
+}
+module.exports.KalturaPermission = KalturaPermission;
+
+util.inherits(KalturaPermission, kaltura.KalturaObjectBase);
+
+
+/**
+ * @param objects array  (readOnly).
+ * @param totalCount int  (readOnly).
+ */
+function KalturaPermissionListResponse(){
+        KalturaPermissionListResponse.super_.call(this);
+        this.objects = null;
+        this.totalCount = null;
+}
+module.exports.KalturaPermissionListResponse = KalturaPermissionListResponse;
+
+util.inherits(KalturaPermissionListResponse, kaltura.KalturaObjectBase);
+
+
+/**
  * @param  url  string    Remote URL, FTP, HTTP or HTTPS 
  *  	 .
  * @param  forceAsyncDownload  bool    Force Import Job 

--- a/lib/managers/KalturaManifestManager.js
+++ b/lib/managers/KalturaManifestManager.js
@@ -240,33 +240,41 @@ KalturaManifestManager.prototype.fetchMaster = function(response, manifestUrl, e
 /**
  * get the current ui conf config file from Kaltura and store it in the cache
  * @param uiConfId
+ * @param entryId
+ * @param partnerId
+ * @param callback
  */
 KalturaManifestManager.prototype.getAndStoreUiConfConfig = function(uiConfId, entryId, partnerId, callback){
 	var callUiConfGetService = function(uiConfId){
 		This.impersonate(partnerId);
 		This.client.uiConf.get(function(result){
 			This.unimpersonate(KalturaConfig.config.client);
-			var uiConfConfig = KalturaUiConfParser.parseUiConfConfig(uiConfId, JSON.parse(result.config));
-			var uiConfConfigfKey = KalturaCache.getUiConfConfig(uiConfId);
-			KalturaCache.set(uiConfConfigfKey, uiConfConfig, KalturaConfig.config.cache.uiConfConfig);
-			
-			if(uiConfConfig && uiConfConfig.trackCuePoints){
-				var entryAdTrackRequiedKey = KalturaCache.getEntryAdTrackRequired(entryId);
-				KalturaCache.set(entryAdTrackRequiedKey, true, KalturaConfig.config.cache.entryAdTrackRequied, function() {
-					if(callback){
-						callback(uiConfConfig);
-					}						
-				});
+			if(result.objectType == 'KalturaAPIException'){
+				KalturaLogger.error('Client [uiConf.get][' + result.code + ']: ' + result.message);
+				callback(null);
 			}
 			else{
-				var entryAdTrackNotRequiedKey = KalturaCache.getEntryAdTrackNotRequired(params.entryId);
-				KalturaCache.set(entryAdTrackNotRequiedKey, true, KalturaConfig.config.cache.entryAdTrackRequied, function() {
-					if(callback){
-						callback(uiConfConfig);
-					}					
-				});
-			}
+				var uiConfConfig = KalturaUiConfParser.parseUiConfConfig(uiConfId, JSON.parse(result.config));
+				var uiConfConfigfKey = KalturaCache.getUiConfConfig(uiConfId);
+				KalturaCache.set(uiConfConfigfKey, uiConfConfig, KalturaConfig.config.cache.uiConfConfig);
 			
+				if(uiConfConfig && uiConfConfig.trackCuePoints){
+					var entryAdTrackRequiedKey = KalturaCache.getEntryAdTrackRequired(entryId);
+					KalturaCache.set(entryAdTrackRequiedKey, true, KalturaConfig.config.cache.entryAdTrackRequied, function() {
+						if(callback){
+							callback(uiConfConfig);
+						}						
+					});
+				}
+				else{
+					var entryAdTrackNotRequiedKey = KalturaCache.getEntryAdTrackNotRequired(params.entryId);
+					KalturaCache.set(entryAdTrackNotRequiedKey, true, KalturaConfig.config.cache.entryAdTrackRequied, function() {
+						if(callback){
+							callback(uiConfConfig);
+						}					
+					});
+				}
+			}
 		}, uiConfId);
 	};
 	
@@ -345,31 +353,38 @@ KalturaManifestManager.prototype.master = function(request, response, params){
 		});
 	};
 	
-	if(params.uiConfId){
-		var uiConfConfigKey = KalturaCache.getUiConfConfig(params.uiConfId);
-		KalturaCache.get(uiConfConfigKey, function(uiConfConfig) {
-			if(!uiConfConfig){
-				This.getAndStoreUiConfConfig(params.uiConfId, params.entryId, params.partnerId, function() {
-					doFetchMaster();
+	This.isPermissionAllowedForPartner(params.partnerId, 'FEATURE_PLAY_SERVER', function(isAllowed) {
+		if(isAllowed){
+			if(params.uiConfId){
+				var uiConfConfigKey = KalturaCache.getUiConfConfig(params.uiConfId);
+				KalturaCache.get(uiConfConfigKey, function(uiConfConfig) {
+					if(!uiConfConfig){
+						This.getAndStoreUiConfConfig(params.uiConfId, params.entryId, params.partnerId, function() {
+							doFetchMaster();
+						});
+					}
+					else{
+						KalturaCache.touch(uiConfConfigKey, KalturaConfig.config.cache.uiConfConfig);
+						if(uiConfConfig.trackCuePoints){
+							var entryAdTrackRequiedKey = KalturaCache.getEntryAdTrackRequired(params.entryId);
+							KalturaCache.touch(entryAdTrackRequiedKey, KalturaConfig.config.cache.entryAdTrackRequied);
+						}
+						else{
+							var entryAdTrackNotRequiedKey = KalturaCache.getEntryAdTrackNotRequired(params.entryId);
+							KalturaCache.touch(entryAdTrackNotRequiedKey, KalturaConfig.config.cache.entryAdTrackRequied);
+						}
+						doFetchMaster();
+					}
 				});
 			}
 			else{
-				KalturaCache.touch(uiConfConfigKey, KalturaConfig.config.cache.uiConfConfig);
-				if(uiConfConfig.trackCuePoints){
-					var entryAdTrackRequiedKey = KalturaCache.getEntryAdTrackRequired(params.entryId);
-					KalturaCache.touch(entryAdTrackRequiedKey, KalturaConfig.config.cache.entryAdTrackRequied);
-				}
-				else{
-					var entryAdTrackNotRequiedKey = KalturaCache.getEntryAdTrackNotRequired(params.entryId);
-					KalturaCache.touch(entryAdTrackNotRequiedKey, KalturaConfig.config.cache.entryAdTrackRequied);
-				}
 				doFetchMaster();
 			}
-		});
-	}
-	else{
-		doFetchMaster();
-	}
+		}
+		else{
+			doFetchMaster();
+		}
+	});
 };
 
 
@@ -690,7 +705,9 @@ KalturaManifestManager.prototype.getRenditionFromCache = function(request, respo
 		KalturaCache.get(uiConfConfigKey, function(uiConfConfig) {
 			if(!uiConfConfig){
 				This.getAndStoreUiConfConfig(playerConfig.uiConfId, entryId, partnerId, function(uiConfConfig) {
-					setTrackCuePointsByUiConfig(uiConfConfig);
+					if(uiConfConfig){
+						setTrackCuePointsByUiConfig(uiConfConfig);
+					}
 					handleManifestContnet();
 				});
 			}


### PR DESCRIPTION
1. Fix uiConf loading flow. If uiConf is not loaded continuing without
   ads.
2. Add permission validation for play server access. Play serve will
   check if play server feature is turned on for partner before continuing
   with ads support flow.
