### PR TITLE
Few bug fixes:

### DIFF
--- a/config/config.ini.template
+++ b/config/config.ini.template
@@ -33,7 +33,7 @@ adHandled = 600
 cuePoint = 600
 uiConfConfig = 600
 playerConfig = 600
-entryAdTrackRequied = 600
+entryAdTrack = 600
 
 entryHandled = 20
 entryRequired = 600

--- a/lib/managers/KalturaManifestManager.js
+++ b/lib/managers/KalturaManifestManager.js
@@ -261,7 +261,7 @@ KalturaManifestManager.prototype.getAndStoreUiConfConfig = function(uiConfId, en
 			
 				if(uiConfConfig && uiConfConfig.trackCuePoints){
 					var entryAdTrackRequiedKey = KalturaCache.getEntryAdTrackRequired(entryId);
-					KalturaCache.set(entryAdTrackRequiedKey, true, KalturaConfig.config.cache.entryAdTrackRequied, function() {
+					KalturaCache.set(entryAdTrackRequiedKey, true, KalturaConfig.config.cache.entryAdTrack, function() {
 						if(callback){
 							callback(uiConfConfig);
 						}						
@@ -269,7 +269,7 @@ KalturaManifestManager.prototype.getAndStoreUiConfConfig = function(uiConfId, en
 				}
 				else{
 					var entryAdTrackNotRequiedKey = KalturaCache.getEntryAdTrackNotRequired(entryId);
-					KalturaCache.set(entryAdTrackNotRequiedKey, true, KalturaConfig.config.cache.entryAdTrackRequied, function() {
+					KalturaCache.set(entryAdTrackNotRequiedKey, true, KalturaConfig.config.cache.entryAdTrack, function() {
 						if(callback){
 							callback(uiConfConfig);
 						}					
@@ -359,11 +359,11 @@ KalturaManifestManager.prototype.master = function(request, response, params){
 						KalturaCache.touch(uiConfConfigKey, KalturaConfig.config.cache.uiConfConfig);
 						if(uiConfConfig.trackCuePoints){
 							var entryAdTrackRequiedKey = KalturaCache.getEntryAdTrackRequired(params.entryId);
-							KalturaCache.set(entryAdTrackRequiedKey, true, KalturaConfig.config.cache.entryAdTrackRequied);
+							KalturaCache.set(entryAdTrackRequiedKey, true, KalturaConfig.config.cache.entryAdTrack);
 						}
 						else{
 							var entryAdTrackNotRequiedKey = KalturaCache.getEntryAdTrackNotRequired(params.entryId);
-							KalturaCache.set(entryAdTrackNotRequiedKey, true, KalturaConfig.config.cache.entryAdTrackRequied);
+							KalturaCache.set(entryAdTrackNotRequiedKey, true, KalturaConfig.config.cache.entryAdTrack);
 						}
 						doFetchMaster();
 					}
@@ -686,12 +686,12 @@ KalturaManifestManager.prototype.getRenditionFromCache = function(request, respo
 		if(uiConfConfig.trackCuePoints){
 			KalturaLogger.log('trackCuePoints is turned on for uiConf with id ' + uiConfId);
 			var entryAdTrackRequiredKey = KalturaCache.getEntryAdTrackRequired(entryId);
-			KalturaCache.touch(entryAdTrackRequiredKey, KalturaConfig.config.cache.entryAdTrackRequied);
+			KalturaCache.touch(entryAdTrackRequiredKey, KalturaConfig.config.cache.entryAdTrack);
 			trackCuePoints = true;
 		}
 		else{
 			var entryAdTrackNotRequiredKey = KalturaCache.getEntryAdTrackNotRequired(entryId);
-			KalturaCache.touch(entryAdTrackNotRequiredKey, KalturaConfig.config.cache.entryAdTrackRequied);
+			KalturaCache.touch(entryAdTrackNotRequiredKey, KalturaConfig.config.cache.entryAdTrack);
 		}
 	};
 	

--- a/lib/managers/KalturaStreamManager.js
+++ b/lib/managers/KalturaStreamManager.js
@@ -80,12 +80,17 @@ var KalturaStreamWatcher = function(manager, params, finishCallback){
 		}
 		
 		if(!this.shouldSaveAdsManifest && !this.shouldSaveNoAdsManifest){
+			this.shouldSaveNoAdsManifest = true;
 			KalturaLogger.log('Entry ad track data flags are not set for entry ' + params.entryId + ' , cuntinuing with no ads only');
+			KalturaCache.set(entryAdTrackNotRequiredKey, true, KalturaConfig.config.cache.entryAdTrack);
 		}
 		
 		doGetManifest();
 	}, function(err) {
 		KalturaLogger.log('Failed to retrieve entry ad track data');
+		this.shouldSaveNoAdsManifest = true;
+		KalturaLogger.log('Entry ad track data flags are not set for entry ' + params.entryId + ' , cuntinuing with no ads only');
+		KalturaCache.set(entryAdTrackNotRequiredKey, true, KalturaConfig.config.cache.entryAdTrack);
 		doGetManifest();
 	});
 };


### PR DESCRIPTION
1. Move segment history limit value to configuration.
2. Save player config on each rendition.
3. Verify entry tracking is on before trying to fetch manifest url.
   Fixes bug where even when the stream is down and no rendition request
   was executed for the entry, the stream watcher still would have tried to
   fetch the manifest and then bedded with an error
