### PR TITLE
Few bug fixes around cue points not being retrieved after a while

### DIFF
--- a/lib/managers/KalturaCuePointsManager.js
+++ b/lib/managers/KalturaCuePointsManager.js
@@ -53,28 +53,31 @@ KalturaCuePointsManager.prototype.verifyEntryRequired = function(entryId){
 	};
 	
 	KalturaCache.get(entryRequiredKey, function(data){
-		if(!data)
+		if(!data){
+			KalturaLogger.log('Deleting cue points for entry ' + entryId);
 			deleteCuePoint();
-	}, deleteCuePoint);
-	
-	if(This.cuePoints[entryId] && This.cuePoints[entryId].cuePoints){
-		KalturaCache.get(oldestSegmentTimeKey, function(oldestSegmentTime){
-			if(oldestSegmentTime){
-				var changed = false;
-				for(var cuePointId in This.cuePoints[entryId].cuePoints){
-					var cuePoint = This.cuePoints[entryId].cuePoints[cuePointId];
-					if((cuePoint.startTime && oldestSegmentTime.offset > (cuePoint.startTime + cuePoint.duration)) || 
-						(cuePoint.triggeredAt*1000 && oldestSegmentTime.timestamp > (cuePoint.triggeredAt*1000 + cuePoint.duration))){
-						KalturaLogger.log('Deleting handled cue point from cache: ' + cuePointId);
-						delete This.cuePoints[entryId].cuePoints[cuePointId];
-						changed = true;
+		}
+		else{
+			if(This.cuePoints[entryId] && This.cuePoints[entryId].cuePoints){
+				KalturaCache.get(oldestSegmentTimeKey, function(oldestSegmentTime){
+					if(oldestSegmentTime){
+						var changed = false;
+						for(var cuePointId in This.cuePoints[entryId].cuePoints){
+							var cuePoint = This.cuePoints[entryId].cuePoints[cuePointId];
+							if((cuePoint.startTime && oldestSegmentTime.offset > (cuePoint.startTime + cuePoint.duration)) || 
+								(cuePoint.triggeredAt*1000 && oldestSegmentTime.timestamp > (cuePoint.triggeredAt*1000 + cuePoint.duration))){
+								KalturaLogger.log('Deleting handled cue point from cache: ' + cuePointId);
+								delete This.cuePoints[entryId].cuePoints[cuePointId];
+								changed = true;
+							}
+						}
+						if(changed)
+							KalturaCache.set(cuePointsKey, This.cuePoints[entryId].cuePoints, KalturaConfig.config.cache.cuePoint);		
 					}
-				}
-				if(changed)
-					KalturaCache.set(cuePointsKey, This.cuePoints[entryId].cuePoints, KalturaConfig.config.cache.cuePoint);		
+				}, function(err){});		
 			}
-		}, function(err){});		
-	}
+		}
+	}, deleteCuePoint);
 };
 
 /**
@@ -129,9 +132,11 @@ KalturaCuePointsManager.prototype.loop = function(){
 		entryIds.push(entryId);
 		this.verifyEntryRequired(entryId);
 	}
-
+	
 	if(!entryIds.length){
 		clearInterval(this.interval);
+		KalturaLogger.log('No entries left to monitor, clearing cue points interval for pId ' + process.pid);
+		this.interval = null;
 		return;
 	}
 	
@@ -198,9 +203,11 @@ KalturaCuePointsManager.prototype.watchEntry = function(params, finishCallback){
 		this.interval = setInterval(function(){
 			if(!This.run){
 				clearInterval(This.interval);
+				KalturaLogger.log('Run variable is false clearing cue points interval for pId ' + process.pid);
+				This.interval = null;
 				return;
 			}
-
+			
 			This.loop();
 		}, 10000);
 	}


### PR DESCRIPTION
1. Clearing interval did not set the class variable to null, thus once
   interval was cleared for a process it would not be re-initiated until a
   server restart was made.
2. Fix race condition: delete handled cue points only if entry is still
   required.
