### PR TITLE
Several bug fixes:

### DIFF
--- a/lib/adIntegration/KalturaAdIntegrationHandler.js
+++ b/lib/adIntegration/KalturaAdIntegrationHandler.js
@@ -19,6 +19,7 @@ KalturaAdIntegrationHandler = {
 	getAdMediaFiles : function(request, cuePoint, cachedUrl, entry, metadata, playerConfig, mediaInfos, sessionId, uiConfConfig, downloadCallback, errorCallback) {
 		
 		var headers = {
+				'User-Agent': request.headers['user-agent'],
 				'x-forwarded-for': request.ip
 		};
 

--- a/lib/managers/KalturaManifestManager.js
+++ b/lib/managers/KalturaManifestManager.js
@@ -325,20 +325,25 @@ KalturaManifestManager.prototype.master = function(request, response, params){
 	
 	var doFetchMaster = function() {
 		This.fetchMaster(response, params.url, params.entryId, function(data, fromCache){
-			var body = data.body;
-			if(fromCache){
-	    		response.log('Returns body from cache');
-	    		This.startWatcher(params.partnerId, params.entryId, params.url, data.renditionsWatchParams); 
+			if(!response.headersSent){
+				var body = data.body;
+				if(fromCache){
+		    		response.log('Returns body from cache');
+		    		This.startWatcher(params.partnerId, params.entryId, params.url, data.renditionsWatchParams); 
+				}
+				else{
+					response.log('Stitching [' + params.entryId + ']');			    
+					body = This.stitchMasterM3U8(params.partnerId, params.entryId, params.uiConfId, params.url, body); 
+				}
+				// set unique id on user session
+				var regex = new RegExp('%40SESSION_ID%40', 'g');
+				body = body.replace(regex, sessionId);
+				response.writeHead(200, {'Content-Type': 'application/vnd.apple.mpegurl'});
+				response.end(body);
 			}
 			else{
-				response.log('Stitching [' + params.entryId + ']');			    
-				body = This.stitchMasterM3U8(params.partnerId, params.entryId, params.uiConfId, params.url, body); 
+				response.log('Watchers not started, Headers where alreay sent to the client, original request probably got timed out!!!');
 			}
-			// set unique id on user session
-			var regex = new RegExp('%40SESSION_ID%40', 'g');
-			body = body.replace(regex, sessionId);
-			response.writeHead(200, {'Content-Type': 'application/vnd.apple.mpegurl'});
-			response.end(body);
 		}, function(err){
 			response.error(err);
 			This.errorFileNotFound(response);

--- a/lib/managers/KalturaSegmentManager.js
+++ b/lib/managers/KalturaSegmentManager.js
@@ -147,16 +147,21 @@ KalturaSegmentManager.prototype.stitch = function(request, response, params){
 	var This = this;
 	var urls = [params.url1, params.url2, params.url3];
 	this.downloadMultiHttpUrls(urls, null, function(localPaths){
-		if(!This.run){
-			response.log('Canceled');
-			response.writeHead(200);
-			response.end('Stopped');
-			return;
+		if(response.headersSent){
+			response.log('Headers where alreay sent to the client, attempting to exec stich segment, original request probably got timed out!!!');
 		}
-		
-		response.log('Handled');
-		response.writeHead(200);
-		response.end('OK');
+		else{
+			if(!This.run){
+				response.log('Canceled');
+				response.writeHead(200);
+				response.end('Stopped');
+				return;
+			}
+			
+			response.log('Handled');
+			response.writeHead(200);
+			response.end('OK');
+		}
 
 		This.exec(params.segmentId, params.offset, params.portion, localPaths);
 	}, 


### PR DESCRIPTION
1. Avoid throwing 'cannot render header error' when tryng to stich
   segments.
2. When fetching master manifest if the request to master manifest times
   out do not start watchers.
3. Add user agent to vast request.
