### PR TITLE
Resolve Fatal Error - filter only on Ad cue points.

### DIFF
--- a/lib/managers/KalturaCuePointsManager.js
+++ b/lib/managers/KalturaCuePointsManager.js
@@ -143,6 +143,7 @@ KalturaCuePointsManager.prototype.loop = function(){
 	var filter = new kaltura.client.objects.KalturaAdCuePointFilter();
 	filter.entryIdIn = entryIds.join(',');
 	filter.statusEqual = kaltura.client.enums.KalturaCuePointStatus.READY;
+	filter.cuePointTypeEqual = kaltura.client.enums.KalturaCuePointType.AD;
 	if(this.lastUpdatedAt)
 		filter.updatedAtGreaterThanOrEqual = this.lastUpdatedAt;
 


### PR DESCRIPTION
The filter did not request only ad cue points for the entry, this caused
other types to be fetched as well ending with Fatal error in the code.
