### PR TITLE
ts preparer bug fix

### DIFF
--- a/lib/media/KalturaTsPreparer.js
+++ b/lib/media/KalturaTsPreparer.js
@@ -179,7 +179,7 @@ var KalturaTsPreparer = {
 					'buffers': inputBuffers.buffers, 
 					'frames': inputFrames, 
 					'framesPosShift': 0,
-					'flags': KalturaTsPreparer.BUFFER_FLAG_TS_HEADER
+					'flags': KalturaTsPreparer.BUFFER_FLAG_TS_HEADER | KalturaTsPreparer.BUFFER_FLAG_FILTER_MEDIA_STREAMS
 				}]);
 
 			callback(null, result);


### PR DESCRIPTION
need to strip off any PAT/PMT packets created by ffmpeg. only the header of
the pre-ad TS segment should be used
