### PR TITLE
bug fix - duplicate frame

### DIFF
--- a/native/node_addons/TsStitcher/ts_stitcher_impl.c
+++ b/native/node_addons/TsStitcher/ts_stitcher_impl.c
@@ -399,7 +399,7 @@ build_layout_impl(
 			}
 			
 			// update output state
-			if (cur_pos[main_media_type] > output_end)
+			if (cur_pos[main_media_type] >= output_end)
 			{
 				break;
 			}


### PR DESCRIPTION
need to break when cur_pos == output_end, since the next segment will have its output_start = the current output_end
