### PR TITLE
use one of the original ts files for mediainfo

### DIFF
--- a/lib/media/KalturaTsPreparer.js
+++ b/lib/media/KalturaTsPreparer.js
@@ -125,7 +125,7 @@ var KalturaTsPreparer = {
     	});
     },
     
-    clipWithFfmpeg: function(ffmpegBin, ffprobeBin, inputBuffers, cutOffset, leftPortion, callback) {
+    clipWithFfmpeg: function(ffmpegBin, ffprobeBin, mediaInfoFile, inputBuffers, cutOffset, leftPortion, callback) {
     	// save the input buffers to a file
     	inputBuffers.writeTempFile(function(err, inputFile) {
     		if (err) {
@@ -134,7 +134,7 @@ var KalturaTsPreparer = {
     		}
     
     		// parse the media info
-    		kaltura.mediaInfo.parse(inputFile, function(mediaInfo) {
+    		kaltura.mediaInfo.parse(mediaInfoFile, function(mediaInfo) {
     			KalturaTsPreparer.logger.log('Parsed media info:' + util.inspect(mediaInfo));
     
     			// build the encoding params
@@ -241,7 +241,7 @@ var KalturaTsPreparer = {
     
     		// clip the bounded section with ffmpeg
     		var cutOffsetSec = (cutOffset - cutDetails.leftOffset) / 90000;
-    		KalturaTsPreparer.clipWithFfmpeg(ffmpegBin, ffprobeBin, boundedSection, cutOffsetSec, leftPortion, function(error, clippedBuffers, clippedFramesInfo) {
+    		KalturaTsPreparer.clipWithFfmpeg(ffmpegBin, ffprobeBin, inputFiles[0], boundedSection, cutOffsetSec, leftPortion, function(error, clippedBuffers, clippedFramesInfo) {
     
     			if (error) {
     				callback(error, null);


### PR DESCRIPTION
when cutting TS files, the part that is cut by the native code may be very short, and mediainfo doesnt parse it (ffprobe does parse it btw)
this problem happened with an audio-only ts in a multi-audio-track live stream
