### PR TITLE
Improve behavior when Wowza restarts

### DIFF
--- a/config/managers.ini.template
+++ b/config/managers.ini.template
@@ -2,6 +2,8 @@
 [manifest]
 ;domain = @MANIFEST_SERVICE_HOSTNAME@
 ;domainPort = 80
+[manifest][rendition]
+maxRetries = 6
 
 [stream]
 ;useCdn = 1

--- a/lib/managers/KalturaManifestManager.js
+++ b/lib/managers/KalturaManifestManager.js
@@ -10,15 +10,21 @@ kaltura.m3u8Parser = require('../protocol/KalturaM3U8Parser');
  * @service manifest
  * 
  * This service is responsible for returning master and rendition manifests to the player.
- * It also triggers the calls to start reniditon manifest watchers and cue-point watcher
+ * It also triggers the calls to start rendition manifest watchers and cue-point watcher
  * and triggers AdIntegrationManager to perform VAST request when required.
  */
 var KalturaManifestManager = function(){
+	if (KalturaConfig.config.manifest.rendition.maxRetries){
+		this.RENDITION_MAX_RETRIES = KalturaConfig.config.manifest.rendition.maxRetries;
+	}
+
+
 };
 util.inherits(KalturaManifestManager, kaltura.KalturaManager);
 
-KalturaManifestManager.RENDITION_RETRY_INTERVAL = 5;
+KalturaManifestManager.RENDITION_RETRY_INTERVAL_MILISECONDS = 5000;
 KalturaManifestManager.RENDITION_IN_MEMORY_CACHE_LIFETIME = 2; 
+KalturaManifestManager.RENDITION_MAX_RETRIES = 6;
 
 /**
  * Set entryRequired in case it is not initialized yet
@@ -389,10 +395,11 @@ KalturaManifestManager.prototype.getRenditionFromCache = function(request, respo
 	else{
 		response.retries = 1;
 	}
-	if(response.retries >= 6){
+
+	if(response.retries >= This.RENDITION_MAX_RETRIES){
 		response.log('Not found in cache');
 		this.errorFileNotFound(response);
-		return;
+		return false;
 	}
 					
 	response.debug('Handling manifest content: entryId: [' + entryId + '], sessionId [' + sessionId + ']');
@@ -425,7 +432,7 @@ KalturaManifestManager.prototype.getRenditionFromCache = function(request, respo
 						else{
 							response.log('Master not found in cache, stitching [' + entryId + ']');			
 							This.loadUiConfConfig(uiConfId, entryId, partnerId, function(uiConfConfig) {
-								body = This.stitchMasterM3U8(partnerId, entryId, uiConfId, uiConfConfigId, masterUrl, true, body);	
+								body = This.stitchMasterM3U8(partnerId, entryId, uiConfId, uiConfConfigId, masterUrl, true, body);
 							});
 													
 						}
@@ -438,10 +445,11 @@ KalturaManifestManager.prototype.getRenditionFromCache = function(request, respo
 				setTimeout(function(){
 					response.log('Rendition [' + renditionId + '] retry [' + response.retries + ']');
 					This.getRenditionFromCache(request, response, partnerId, entryId, uiConfId, uiConfConfigId, renditionId, masterUrl, sessionId, playerConfig, sessionStartTime);
-				}, KalturaManifestManager.RENDITION_RETRY_INTERVAL * 1000);
+				}, KalturaManifestManager.RENDITION_RETRY_INTERVAL_MILISECONDS );
 			}
 		});			
 	}
+	return true;
 };
 
 
@@ -463,10 +471,12 @@ KalturaManifestManager.prototype.rendition = function(request, response, params)
 	}
 
 	var masterUrl = new Buffer(params.master, 'base64').toString('ascii');
-	this.getRenditionFromCache(request, response, params.partnerId, params.entryId, params.uiConfId, params.uiConfConfigId, params.renditionId, masterUrl, params.sessionId, params.playerConfig, params.sessionStartTime, params.originDc);
-	
-	var entryRequiredKey = KalturaCache.getKey(KalturaCache.ENTRY_REQUIRED_KEY_PREFIX, [params.entryId]);
-	KalturaCache.touch(entryRequiredKey, KalturaConfig.config.cache.entryRequired);
+	if (this.getRenditionFromCache(request, response, params.partnerId, params.entryId, params.uiConfId, params.uiConfConfigId, params.renditionId,
+			masterUrl, params.sessionId, params.playerConfig, params.sessionStartTime, params.originDc)) {
+
+		var entryRequiredKey = KalturaCache.getKey(KalturaCache.ENTRY_REQUIRED_KEY_PREFIX, [params.entryId]);
+		KalturaCache.touch(entryRequiredKey, KalturaConfig.config.cache.entryRequired);
+	}
 };
 
 /**

--- a/lib/managers/KalturaStreamManager.js
+++ b/lib/managers/KalturaStreamManager.js
@@ -119,7 +119,7 @@ KalturaStreamWatcher.prototype = {
 				This.appendToEntryRequired(data);
 				KalturaCache.touch(This.mediaInfoKey, KalturaConfig.config.cache.encodingParams);
 				KalturaCache.touch(This.encodingParamsKey, KalturaConfig.config.cache.encodingParams);
-				KalturaCache.touch(This.fillerEncodingParamsKey, KalturaConfig.config.cache.fillerMedia);	
+				KalturaCache.touch(This.fillerEncodingParamsKey, KalturaConfig.config.cache.fillerMedia);
 				KalturaCache.touch(This.uiConfConfigKey, KalturaConfig.config.cache.fillerMedia);
 			}
 			else{
@@ -413,12 +413,14 @@ KalturaStreamWatcher.prototype = {
 				KalturaLogger.log('[' + This.uniqueLoopId + '] Cue-point [' + this.cuePoint.id + '] ad current offset [' + this.adCurOffset + ']');
 			}
 		}
-		
-		var newManifestContent = kaltura.m3u8Parser.buildM3U8(manifest.headers, newResult, manifest.footers);
-		KalturaLogger.debug('[' + this.uniqueLoopId + '] newManifestContent: ' + newManifestContent);		
-		this.clearUnusedUrlTranslations();
-		
-		this.saveNewManifest(newManifestContent, [preSegmentStitchParams, postSegmentStitchParams]);
+
+		if (newResult.length > 0 ) {
+			var newManifestContent = kaltura.m3u8Parser.buildM3U8(manifest.headers, newResult, manifest.footers);
+			KalturaLogger.debug('[' + this.uniqueLoopId + '] newManifestContent: ' + newManifestContent);
+			this.clearUnusedUrlTranslations();
+
+			this.saveNewManifest(newManifestContent, [preSegmentStitchParams, postSegmentStitchParams]);
+		}
 	},
 
 	/**
@@ -628,7 +630,7 @@ KalturaStreamWatcher.prototype = {
 		if(!this.manager.run){
 			return;
 		}
-		
+
 		// sleep until next cycle
 		var curTime = new Date().getTime();
 		var sleepTime = Math.max(0, this.cycleStartTime + KalturaStreamWatcher.CYCLE_INTERVAL - curTime);
@@ -642,34 +644,37 @@ KalturaStreamWatcher.prototype = {
 	 * Fetch the manifest from the cdn and call the manifest handler
 	 */
 	getManifest: function(){
-		this.uniqueLoopId = KalturaUtils.getUniqueId();
-		KalturaLogger.log('[' + this.uniqueLoopId + '] getting manifest for [' + this.entryId + '] rendition [' + this.renditionId + '] watcher id [' + this.watcherId + '] uiconf [' + this.uiConfConfigId + ']');
-		KalturaCache.set(this.renditionManifestHandledKey, true, KalturaConfig.config.cache.watcherHandled);
+		This = this;
+		This.uniqueLoopId = KalturaUtils.getUniqueId();
+		KalturaLogger.log('[' + This.uniqueLoopId + '] getting manifest for [' + This.entryId + '] rendition [' + This.renditionId + '] watcher id [' + This.watcherId + '] uiconf [' + This.uiConfConfigId + ']');
+		KalturaCache.set(This.renditionManifestHandledKey, true, KalturaConfig.config.cache.watcherHandled);
 		
 		//verify if entry is still required
-		this.verifyTrackingRequired();
+		This.verifyTrackingRequired();
 
-		if(new Date().getTime() > (this.startTime + KalturaStreamWatcher.MINIMUM_RUN_PERIOD) && !this.trackerRequired){
-			KalturaCache.del(this.renditionManifestHandledKey);
-			KalturaLogger.log('Done ' + this.entryId);
-			if(this.finishCallback && typeof this.finishCallback === 'function'){
-				this.finishCallback();
+		if(new Date().getTime() > (This.startTime + KalturaStreamWatcher.MINIMUM_RUN_PERIOD) && !This.trackerRequired){
+			KalturaCache.del(This.renditionManifestHandledKey);
+			KalturaLogger.log('Done ' + This.entryId);
+			if(This.finishCallback && typeof This.finishCallback === 'function'){
+				This.finishCallback();
 			}
 			return;
 		}
 
-		var This = this;
-		KalturaUtils.getHttpUrl(this.url, null, function(manifestContent){
+		var This = This;
+		KalturaUtils.getHttpUrl(This.url, null, function(manifestContent){
 			KalturaLogger.log('[' + This.uniqueLoopId + '] Manifest fetched [' + This.entryId + '] [' + This.url + ']');
 			
 			This.loadCuePoints(function(){
 				KalturaLogger.log('[' + This.uniqueLoopId + '] Stitch manifest [' + This.entryId + '] rendition [' + This.renditionId + '] elapsedTime [' + JSON.stringify(This.elapsedTime) + ']');
 				This.stitchManifest(manifestContent);
 			});
-		}, function(err){
-			This.cycleStartTime = new Date().getTime();
-			KalturaLogger.error('[' + This.uniqueLoopId + '] Failed to fetch manifest [' + This.url + ']: ' + err);
-			This.keepWatching();
+		}, function(err, statusCode){
+			KalturaLogger.error('[' + This.uniqueLoopId + '] Failed to fetch manifest [' + This.url + ']: ' + err + ' Http status code:' + statusCode);
+			KalturaCache.del(This.renditionManifestHandledKey);
+			//This.cycleStartTime = new Date().getTime();
+			//KalturaLogger.error('[' + This.uniqueLoopId + '] Failed to fetch manifest [' + This.url + ']: ' + err);
+			//This.keepWatching();
 		});
 	},
 

--- a/lib/managers/KalturaStreamManager.js
+++ b/lib/managers/KalturaStreamManager.js
@@ -644,37 +644,33 @@ KalturaStreamWatcher.prototype = {
 	 * Fetch the manifest from the cdn and call the manifest handler
 	 */
 	getManifest: function(){
-		This = this;
-		This.uniqueLoopId = KalturaUtils.getUniqueId();
-		KalturaLogger.log('[' + This.uniqueLoopId + '] getting manifest for [' + This.entryId + '] rendition [' + This.renditionId + '] watcher id [' + This.watcherId + '] uiconf [' + This.uiConfConfigId + ']');
-		KalturaCache.set(This.renditionManifestHandledKey, true, KalturaConfig.config.cache.watcherHandled);
+		this.uniqueLoopId = KalturaUtils.getUniqueId();
+		KalturaLogger.log('[' + this.uniqueLoopId + '] getting manifest for [' + this.entryId + '] rendition [' + this.renditionId + '] watcher id [' + this.watcherId + '] uiconf [' + this.uiConfConfigId + ']');
+		KalturaCache.set(this.renditionManifestHandledKey, true, KalturaConfig.config.cache.watcherHandled);
 		
 		//verify if entry is still required
-		This.verifyTrackingRequired();
+		this.verifyTrackingRequired();
 
-		if(new Date().getTime() > (This.startTime + KalturaStreamWatcher.MINIMUM_RUN_PERIOD) && !This.trackerRequired){
-			KalturaCache.del(This.renditionManifestHandledKey);
-			KalturaLogger.log('Done ' + This.entryId);
-			if(This.finishCallback && typeof This.finishCallback === 'function'){
-				This.finishCallback();
+		if(new Date().getTime() > (this.startTime + KalturaStreamWatcher.MINIMUM_RUN_PERIOD) && !this.trackerRequired){
+			KalturaCache.del(this.renditionManifestHandledKey);
+			KalturaLogger.log('Done ' + this.entryId);
+			if(this.finishCallback && typeof this.finishCallback === 'function'){
+				this.finishCallback();
 			}
 			return;
 		}
 
-		var This = This;
-		KalturaUtils.getHttpUrl(This.url, null, function(manifestContent){
+		var This = this;
+		KalturaUtils.getHttpUrl(this.url, null, function(manifestContent){
 			KalturaLogger.log('[' + This.uniqueLoopId + '] Manifest fetched [' + This.entryId + '] [' + This.url + ']');
 			
 			This.loadCuePoints(function(){
 				KalturaLogger.log('[' + This.uniqueLoopId + '] Stitch manifest [' + This.entryId + '] rendition [' + This.renditionId + '] elapsedTime [' + JSON.stringify(This.elapsedTime) + ']');
 				This.stitchManifest(manifestContent);
 			});
-		}, function(err, statusCode){
-			KalturaLogger.error('[' + This.uniqueLoopId + '] Failed to fetch manifest [' + This.url + ']: ' + err + ' Http status code:' + statusCode);
+		}, function(err){
+			KalturaLogger.error('[' + This.uniqueLoopId + '] Failed to fetch manifest [' + This.url + ']: ' + err );
 			KalturaCache.del(This.renditionManifestHandledKey);
-			//This.cycleStartTime = new Date().getTime();
-			//KalturaLogger.error('[' + This.uniqueLoopId + '] Failed to fetch manifest [' + This.url + ']: ' + err);
-			//This.keepWatching();
 		});
 	},
 

--- a/lib/managers/KalturaTestAdServerManager.js
+++ b/lib/managers/KalturaTestAdServerManager.js
@@ -36,7 +36,7 @@ KalturaTestAdServerManager.prototype.getVast = function(request, response, param
 		response.log('handled');
 		This.okResponse(response, vastContent, 'text/xml');		
 		},function (err) {
-			response.end('Not found');
+			response.end('Vast not found due to error :' + err );
 	});
 };
 


### PR DESCRIPTION
PLAT-5307
When Wowza restarts we get peaks of CPU and wrongly treat manifest
This fix will remove the manifest from the cache and improve the response when the rendition is not ready