### PR TITLE
delete check validation after split the cache return value

### DIFF
--- a/lib/managers/helpers/AdBreakKeyHelper.js
+++ b/lib/managers/helpers/AdBreakKeyHelper.js
@@ -85,8 +85,6 @@ class AdBreakKeyHelper {
 			if (!values[i] || values[i] === null || values[i].length === 0)
 				continue;
 			const singleValue = values[i].split(READY_ADS_INNER_DATA_SIGN_SEPARATOR);
-			if (singleValue.length < 1 || singleValue.length > 4)
-				throw new Error(`Unexpected value found in cache for ad breaks [${this.value} - failed on ${values[i]}`);
 			if (singleValue.length === 1)
 			{
 				if (singleValue[0] === BLOCKED)


### PR DESCRIPTION
can be more than 4 ':' in cache value