### PR TITLE
Update KalturaAdIntegrationManager.js

### DIFF
--- a/lib/managers/KalturaAdIntegrationManager.js
+++ b/lib/managers/KalturaAdIntegrationManager.js
@@ -531,6 +531,18 @@ KalturaAdIntegrationManager.prototype.getAdMediaFiles = function(request, respon
 	
 	response.log('Parsing ads from [' + cuePoint.sourceUrl + '] cue-point [' + cuePoint.id + '] session [' + sessionId + '] partner [' + cuePoint.partnerId + '] entry [' + cuePoint.entryId + '] headers [' + JSON.stringify(headers) + ']');
 	
+	KalturaCache.set(
+		KalturaCache.getKey(KalturaCache.HEADERS_PREFIX, [sessionId]),
+		headers,
+		KalturaConfig.config.cache.sessionHeaders,
+		function(){
+			KalturaLogger.log('Successfully set headers [' + util.inspect(headers) +  '] for sessionId ' + sessionId + ' from getAdMediaFiles');
+		},
+		function(){
+			KalturaLogger.error('Failed to set headers for sessionId '+ sessionId + ' from getAdMediaFiles')
+		}
+	);
+
 	if(cachedUrl == null){
 		KalturaUrlTokenMapper.mapFixedTokens(request, cuePoint, entry, metadata, playerConfig, function(cachedUrl){
 			evaluatedUrl = KalturaUrlTokenMapper.mapDynamicTokens(request, cachedUrl, playerConfig);
@@ -843,11 +855,13 @@ KalturaAdIntegrationManager.prototype.sendBeacon = function(request, response, p
 					var headers = value;
 					if (headers)
 					{
-						KalturaLogger.log('Trying to send beacon with headers [' + util.inspect(headers) + '] for tracking id  [' + + params.trackingId + '] type [' + eventType + '] partner [' + params.partnerId + ']');
+						KalturaCache.touch(KalturaCache.getKey(KalturaCache.HEADERS_PREFIX, [params.sessionId]), KalturaConfig.config.cache.sessionHeaders);
+						KalturaLogger.log('Sending beacon for tracking id [' + params.trackingId + '] type [' + eventType + '] partner [' + params.partnerId + '] session id [' + params.sessionId + '] with headers [' + util.inspect(headers) + ']');
 						options.headers = headers;
 					}
 					else
-						KalturaLogger.log('Sending beacon with no headers for tracking id  [' + params.trackingId + '] type [' + eventType + '] partner [' + params.partnerId + ']');
+						KalturaLogger.log('Sending beacon for tracking id [' + params.trackingId + '] type [' + eventType + '] partner [' + params.partnerId + '] session id [' + params.sessionId + '] with no headers');
+
 					sendBeaconRequest(options, url, eventType);
 				},
 				function (error)


### PR DESCRIPTION
Fix beacon sending log messages to include sessionID and TrackingInfo
Set header cache key on getAdMediaFile -  this to ensure the value will exist on the same DC, where the beacon sending operation occurs