### PR TITLE
fix entryRequired corruption

### DIFF
--- a/lib/managers/KalturaMediaManager.js
+++ b/lib/managers/KalturaMediaManager.js
@@ -491,69 +491,87 @@ KalturaMediaManager.prototype.decideCanPlayAd = function(response, entryId, cueP
 	var dcChanged = (originDc !== KalturaUtils.getCurrentDc());
 	var entryRequiredKey = KalturaCache.getKey(KalturaCache.ENTRY_REQUIRED_KEY_PREFIX, [entryId]);
 	
-	KalturaCache.get(entryRequiredKey, function(entryRequired){
-		var renditionIds = [];
-		var allSessionServerAdIdsKeys = [];
-		if(entryRequired){
-			renditionIds = KalturaCache.extractEntryRequiredValue(entryRequired);
-			for(var i = 0; i < renditionIds.length; i++){ 
-				if(renditionIds[i].trim().length){
-					allSessionServerAdIdsKeys.push(KalturaCache.getKey(KalturaCache.SERVER_AD_ID_KEY_PREFIX, [cuePointId, renditionIds[i], sessionId]));
-				}						
-			}
-			
-			KalturaCache.getMulti(allSessionServerAdIdsKeys, function(allSessionServerAdIds){
-				if(!allSessionServerAdIds || Object.keys(allSessionServerAdIds).length == 0){
-					callback('no', '1:Session Server Ad Ids not found in cache, redirecting to original ts: requested after ' + preparationTime + ' seconds, dc changed: ' + dcChanged);
-					return;
-				}				
-				else{
-					var metadataKeys = [];
-					var preSegmentId = KalturaCache.getPreSegmentId(cuePointId, renditionId);
-					metadataKeys.push(KalturaCache.getKey(KalturaCache.METADATA_READY_KEY_PREFIX, [preSegmentId]));
-					for(var sessionServerAdIdKey in allSessionServerAdIds){
-						if(!allSessionServerAdIds[sessionServerAdIdKey]){
-							if (cuePointTriggeredAt && cuePointTriggeredAt <= sessionStartTime) {
-								callback('no', '8:Session started at ' + sessionStartTime + ' after cuePoint at ' + cuePointTriggeredAt + ', redirecting to original ts: requested after ' + preparationTime + ' seconds, dc changed: ' + dcChanged);
-							} else {
-								callback('no', '2:Session Server Ad ids missing for key ' + sessionServerAdIdKey + ', redirecting to original ts: requested after ' + preparationTime + ' seconds, dc changed: ' + dcChanged);
-							}
-							return;
-						}
-						else{
-							var serverAdIds = KalturaCache.extractSessionServerAdIdValue(allSessionServerAdIds[sessionServerAdIdKey]);
-							for(var i = 0; i<= serverAdIds.length; i++){
-								if(!serverAdIds[i]){
-									continue;
-								}
-								metadataKeys.push(KalturaCache.getKey(KalturaCache.METADATA_READY_KEY_PREFIX, [serverAdIds[i].id]));
-							}									
-						}
-					}
-					KalturaCache.getMulti(metadataKeys, function(data){
-						for(var i=0; i<metadataKeys.length; i++){
-							if(!(data[metadataKeys[i]])){
-								callback('no', '3:Metadata missing for ' + metadataKeys[i] + ', redirecting to original ts');
-								return;
-							}
-						}
-						callback('yes', null);
-						return;
-					}, function(err){
-						callback('no', '5:Error getting metadata status from cache, redirecting to original ts');
-						return;
-					});
-				}
+	KalturaCache.get(entryRequiredKey, function(entryRequired) {
+            var renditionIds = [];
+            var mediaInfoKeys = [];
+            var allSessionServerAdIdsKeys = [];
+            if(entryRequired){
+                renditionIds = KalturaCache.extractEntryRequiredValue(entryRequired);
+                for(var i = 0; i < renditionIds.length; i++){
+                    if(renditionIds[i].trim().length){
+                        mediaInfoKeys.push(KalturaCache.getKey(KalturaCache.MEDIA_INFO_KEY_PREFIX, [renditionIds[i]]));
+                    }
+                }
+                KalturaCache.getMulti(mediaInfoKeys, function(mediaInfos) {
+                    if (!mediaInfos) {
+                        callback('no', '9:mediaInfo not found in cache, redirecting to original ts');
+                        return;
+                    }
+                    for(var mediaInfoId in mediaInfos) {
+                        if (!mediaInfos[mediaInfoId]) {
+                            response.debug('Skipping mediaInfoId [' + mediaInfoId + '], due to undefined entry in mediaInfos');
+                            continue;
+                        }
+                        var renditionId = KalturaCache.getRenditionIdFromMediaInfo(mediaInfoId);
+                        allSessionServerAdIdsKeys.push(KalturaCache.getKey(KalturaCache.SERVER_AD_ID_KEY_PREFIX, [cuePointId, renditionId, sessionId]));
+                    }
 
-			}, function (err){
-				callback('no', '6:Server Ad Ids not found in cache, redirecting to original ts: requested after ' + preparationTime + ' seconds, dc changed: ' + dcChanged);	
-				return;
-			});
-		}			
-	}, function(err){
-		callback('no', '7:entryRequired not found in cache, redirecting to original ts');			
-		return;
-	});
+                    KalturaCache.getMulti(allSessionServerAdIdsKeys, function(allSessionServerAdIds){
+                        if(!allSessionServerAdIds || Object.keys(allSessionServerAdIds).length == 0){
+                            callback('no', '1:Session Server Ad Ids not found in cache, redirecting to original ts: requested after ' + preparationTime + ' seconds, dc changed: ' + dcChanged);
+                            return;
+                        }
+                        else{
+                            var metadataKeys = [];
+                            var preSegmentId = KalturaCache.getPreSegmentId(cuePointId, renditionId);
+                            metadataKeys.push(KalturaCache.getKey(KalturaCache.METADATA_READY_KEY_PREFIX, [preSegmentId]));
+                            for(var sessionServerAdIdKey in allSessionServerAdIds){
+                                if(!allSessionServerAdIds[sessionServerAdIdKey]){
+                                    if (cuePointTriggeredAt && cuePointTriggeredAt <= sessionStartTime) {
+                                        callback('no', '8:Session started at ' + sessionStartTime + ' after cuePoint at ' + cuePointTriggeredAt + ', redirecting to original ts: requested after ' + preparationTime + ' seconds, dc changed: ' + dcChanged);
+                                    } else {
+                                        callback('no', '2:Session Server Ad ids missing for key ' + sessionServerAdIdKey + ', redirecting to original ts: requested after ' + preparationTime + ' seconds, dc changed: ' + dcChanged);
+                                    }
+                                    return;
+                                }
+                                else{
+                                    var serverAdIds = KalturaCache.extractSessionServerAdIdValue(allSessionServerAdIds[sessionServerAdIdKey]);
+                                    for(var i = 0; i<= serverAdIds.length; i++){
+                                        if(!serverAdIds[i]){
+                                            continue;
+                                        }
+                                        metadataKeys.push(KalturaCache.getKey(KalturaCache.METADATA_READY_KEY_PREFIX, [serverAdIds[i].id]));
+                                    }
+                                }
+                            }
+                            KalturaCache.getMulti(metadataKeys, function(data){
+                                for(var i=0; i<metadataKeys.length; i++){
+                                    if(!(data[metadataKeys[i]])){
+                                        callback('no', '3:Metadata missing for ' + metadataKeys[i] + ', redirecting to original ts');
+                                        return;
+                                    }
+                                }
+                                callback('yes', null);
+                                return;
+                            }, function(err){
+                                callback('no', '5:Error getting metadata status from cache, redirecting to original ts');
+                                return;
+                            });
+                        }
+
+                    }, function (err){
+                        callback('no', '6:Server Ad Ids not found in cache, redirecting to original ts: requested after ' + preparationTime + ' seconds, dc changed: ' + dcChanged);
+                        return;
+                    });
+                }, function(err) {
+                    callback('no', '9:mediaInfo not found in cache, redirecting to original ts');
+                    return;
+                })
+            }
+        }, function(err){
+            callback('no', '7:entryRequired not found in cache, redirecting to original ts');
+            return;
+    	});
 };
 
 /**


### PR DESCRIPTION
If there's a rendition in entryRequired structure which hasn't corresponding mediaInfo no ads will be stitched at all and all breaks will be marked as no.  The fix is to check only renditions that has mediaInfo before deciding if a break can be stitched