### PR TITLE
avoid exception if VAST contains empty array

### DIFF
--- a/lib/managers/KalturaAdIntegrationManager.js
+++ b/lib/managers/KalturaAdIntegrationManager.js
@@ -879,7 +879,8 @@ KalturaAdIntegrationManager.prototype.sendBeacon = function(request, response, p
 		};
 
 		for(var i=0; i < events.length; i++){
-			httpGet(events[i].trim(), eventType, seq);
+			if (events[i])
+				httpGet(events[i].trim(), eventType, seq);
 		}				
 	};
 	


### PR DESCRIPTION
Once fixing the exception on the vast client parser - the send beacon should check if the urlTemplate is not empty to avoid exceptions