### PR TITLE
Ignore invalid sessions + stop treating cache touch of empty values as errors

### DIFF
--- a/lib/managers/KalturaAdIntegrationManager.js
+++ b/lib/managers/KalturaAdIntegrationManager.js
@@ -92,8 +92,8 @@ KalturaAdIntegrationManager.prototype.stitchCuePoints = function(request, respon
 	var entry = null;
 	var metadata = null;	
 	var metadataProfileId = null;
-	
-	for(var i = 0; i < renditionIds.length; i++){ 
+
+	for(var i = 0; i < renditionIds.length; i++){
 		if(renditionIds[i].trim().length){
 			mediaInfoKeys.push(KalturaCache.getKey(KalturaCache.MEDIA_INFO_KEY_PREFIX, [renditionIds[i]]));
 			encodingParamsKeys.push(KalturaCache.getKey(KalturaCache.ENCODING_PARAMS_KEY_PREFIX, [renditionIds[i]]));
@@ -134,7 +134,7 @@ KalturaAdIntegrationManager.prototype.stitchCuePoints = function(request, respon
 						KalturaCache.get(cuePointUrlKey, function(cachedUrl){
 							if(cachedUrl){
 								response.debug('Cue point url found in cache: [' + cachedUrl + '] for cue point [' + cuePoint.id + ']');
-								This.stitchAd(request, response, params.partnerId, cachedUrl, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
+								This.stitchAd(request, response, params.partnerId, cachedUrl, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig, params.sessionStartTime);
 							}
 							else{
 								response.debug('Cue point url not found in cache for cue point [' + cuePoint.id + ']');
@@ -142,11 +142,11 @@ KalturaAdIntegrationManager.prototype.stitchCuePoints = function(request, respon
 									This.getEntryAndMetadata(params.partnerId, params.entryId, metadataProfileId, function(entryObj, metadataObj){
 										entry = entryObj;
 										metadata = metadataObj;
-										This.stitchAd(request, response, params.partnerId, null, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
+										This.stitchAd(request, response, params.partnerId, null, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig, params.sessionStartTime);
 									});
 								}
 								else{
-									This.stitchAd(request, response, params.partnerId, null, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
+									This.stitchAd(request, response, params.partnerId, null, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig, params.sessionStartTime);
 								}
 							}
 							}, function (err) {
@@ -155,11 +155,11 @@ KalturaAdIntegrationManager.prototype.stitchCuePoints = function(request, respon
 									This.getEntryAndMetadata(params.partnerId, params.entryId, metadataProfileId, function(entryObj, metadataObj){
 										entry = entryObj;
 										metadata = metadataObj;
-										This.stitchAd(request, response, null, params.partnerId, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
+										This.stitchAd(request, response, null, params.partnerId, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig, params.sessionStartTime);
 									});
 								}
 								else{
-									This.stitchAd(request, response, null, params.partnerId, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
+									This.stitchAd(request, response, null, params.partnerId, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig, params.sessionStartTime);
 								}
 							});
 					}, function(err){
@@ -191,7 +191,7 @@ KalturaAdIntegrationManager.prototype.stitchCuePoints = function(request, respon
  * @param sessionId
  * @param uiConfConfig
  */
-KalturaAdIntegrationManager.prototype.stitchAd = function(request, response, partnerId, cachedUrl, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, sessionId, uiConfConfig ) {
+KalturaAdIntegrationManager.prototype.stitchAd = function(request, response, partnerId, cachedUrl, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, sessionId, uiConfConfig, sessionStartTime ) {
 	var This = this;
 
 	var stitchAdForEncodingId = function(cuePointId, renditionId, encodingId, adFileId, adFileInfo){
@@ -212,7 +212,7 @@ KalturaAdIntegrationManager.prototype.stitchAd = function(request, response, par
 
 	};
 
-	this.getAdMediaFiles(request, response, cuePoint, cachedUrl, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, sessionId, uiConfConfig, function(adFileId, adFileInfo){
+	this.getAdMediaFiles(request, response, cuePoint, cachedUrl, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, sessionId, uiConfConfig, sessionStartTime, function(adFileId, adFileInfo){
 		response.log('Handling ad file [' + adFileInfo.fileURL + '] session [' + sessionId +']');			
 		for(var i = 0; i < adFileInfo.mediaInfoIds.length; i++){
 			if(adFileInfo.mediaInfoIds[i].trim().length){	
@@ -308,7 +308,7 @@ KalturaAdIntegrationManager.prototype.getEntryAndMetadata = function(partnerId, 
  * @param errorCallback
  * @returns
  */
-KalturaAdIntegrationManager.prototype.getAdMediaFiles = function(request, response, cuePoint, cachedUrl, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, sessionId, uiConfConfig, downloadCallback, errorCallback) {
+KalturaAdIntegrationManager.prototype.getAdMediaFiles = function(request, response, cuePoint, cachedUrl, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, sessionId, uiConfConfig, sessionStartTime,  downloadCallback, errorCallback) {
 	var This = this;	
 	
 	var headers = {
@@ -544,16 +544,42 @@ KalturaAdIntegrationManager.prototype.getAdMediaFiles = function(request, respon
 		}
 	);
 
-	if(cachedUrl == null){
-		KalturaUrlTokenMapper.mapFixedTokens(request, cuePoint, entry, metadata, playerConfig, function(cachedUrl){
-			evaluatedUrl = KalturaUrlTokenMapper.mapDynamicTokens(request, cachedUrl, playerConfig);
-			doGetAdMediaFiles(evaluatedUrl);
-		});
+	var mapURLandGetMediaFiles = function() {
+        if (cachedUrl == null) {
+            KalturaUrlTokenMapper.mapFixedTokens(request, cuePoint, entry, metadata, playerConfig, function (cachedUrl) {
+                evaluatedUrl = KalturaUrlTokenMapper.mapDynamicTokens(request, cachedUrl, playerConfig);
+                doGetAdMediaFiles(evaluatedUrl);
+            });
+        }
+        else {
+            evaluatedUrl = KalturaUrlTokenMapper.mapDynamicTokens(request, cachedUrl, playerConfig);
+            doGetAdMediaFiles(evaluatedUrl);
+        }
+    };
+
+
+	var isNewSession = true;
+	if (sessionStartTime && (sessionStartTime < (Math.floor(Date.now() / 1000) - 1800)))
+        isNewSession = false;
+
+	if (isNewSession) {
+        mapURLandGetMediaFiles();
 	}
-	else{
-		evaluatedUrl = KalturaUrlTokenMapper.mapDynamicTokens(request, cachedUrl, playerConfig);
-		doGetAdMediaFiles(evaluatedUrl);			
-	}
+	else {
+		var segmentFetchedKey =  KalturaCache.getKey(KalturaCache.SEGMENT_FETCHED_PREFIX, [sessionId]);
+		KalturaCache.get(segmentFetchedKey,
+			function(value) {
+				if (value) {
+                    mapURLandGetMediaFiles();
+                } else {
+                    response.error('Session [' + sessionId + '] with sessionStartTime [' + sessionStartTime + '] did not request segments recnetly. Ignoring Vast request');
+                }
+            },
+			function(error) {
+				response.error('Session [' + sessionId + '] with sessionStartTime [' + sessionStartTime + '] did not request segments recnetly. Ignoring Vast request');
+            }
+		);
+    }
 };
 
 /**

--- a/lib/managers/KalturaAdIntegrationManager.js
+++ b/lib/managers/KalturaAdIntegrationManager.js
@@ -134,19 +134,19 @@ KalturaAdIntegrationManager.prototype.stitchCuePoints = function(request, respon
 						KalturaCache.get(cuePointUrlKey, function(cachedUrl){
 							if(cachedUrl){
 								response.debug('Cue point url found in cache: [' + cachedUrl + '] for cue point [' + cuePoint.id + ']');
-								This.stitchAd(request, response, params.partnerId, cachedUrl, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
+								This.stitchAd(request, response, params, cachedUrl, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, uiConfConfig);
 							}
 							else{
 								response.debug('Cue point url not found in cache for cue point [' + cuePoint.id + ']');
 								if(!entry){
-									This.getEntryAndMetadata(params.partnerId, params, metadataProfileId, function(entryObj, metadataObj){
+									This.getEntryAndMetadata(params.partnerId, params.entryId, metadataProfileId, function(entryObj, metadataObj){
 										entry = entryObj;
 										metadata = metadataObj;
-										This.stitchAd(request, response, params, null, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
+										This.stitchAd(request, response, params, null, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, uiConfConfig);
 									});
 								}
 								else{
-									This.stitchAd(request, response, params, null, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
+									This.stitchAd(request, response, params, null, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, uiConfConfig);
 								}
 							}
 							}, function (err) {
@@ -155,11 +155,11 @@ KalturaAdIntegrationManager.prototype.stitchCuePoints = function(request, respon
 									This.getEntryAndMetadata(params.partnerId, params.entryId, metadataProfileId, function(entryObj, metadataObj){
 										entry = entryObj;
 										metadata = metadataObj;
-										This.stitchAd(request, response, null, params, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
+										This.stitchAd(request, response, params, null, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, uiConfConfig);
 									});
 								}
 								else{
-									This.stitchAd(request, response, null, params, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
+									This.stitchAd(request, response, params, null, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, uiConfConfig);
 								}
 							});
 					}, function(err){
@@ -191,7 +191,7 @@ KalturaAdIntegrationManager.prototype.stitchCuePoints = function(request, respon
  * @param sessionId
  * @param uiConfConfig
  */
-KalturaAdIntegrationManager.prototype.stitchAd = function(request, response, params, cachedUrl, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, sessionId, uiConfConfig) {
+KalturaAdIntegrationManager.prototype.stitchAd = function(request, response, params, cachedUrl, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, uiConfConfig) {
 	var This = this;
 
 	var stitchAdForEncodingId = function(cuePointId, renditionId, encodingId, adFileId, adFileInfo){
@@ -212,8 +212,8 @@ KalturaAdIntegrationManager.prototype.stitchAd = function(request, response, par
 
 	};
 
-	this.getAdMediaFiles(request, response, cuePoint, cachedUrl, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, sessionId, uiConfConfig, params.sessionStartTime, function(adFileId, adFileInfo){
-		response.log('Handling ad file [' + adFileInfo.fileURL + '] session [' + sessionId +']');			
+	this.getAdMediaFiles(request, response, cuePoint, cachedUrl, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig, params.sessionStartTime, function(adFileId, adFileInfo){
+		response.log('Handling ad file [' + adFileInfo.fileURL + '] session [' + params.sessionId +']');			
 		for(var i = 0; i < adFileInfo.mediaInfoIds.length; i++){
 			if(adFileInfo.mediaInfoIds[i].trim().length){	
 				var renditionId = KalturaCache.getRenditionIdFromMediaInfo(adFileInfo.mediaInfoIds[i]);

--- a/lib/managers/KalturaAdIntegrationManager.js
+++ b/lib/managers/KalturaAdIntegrationManager.js
@@ -134,19 +134,19 @@ KalturaAdIntegrationManager.prototype.stitchCuePoints = function(request, respon
 						KalturaCache.get(cuePointUrlKey, function(cachedUrl){
 							if(cachedUrl){
 								response.debug('Cue point url found in cache: [' + cachedUrl + '] for cue point [' + cuePoint.id + ']');
-								This.stitchAd(request, response, params.partnerId, cachedUrl, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig, params.sessionStartTime);
+								This.stitchAd(request, response, params.partnerId, cachedUrl, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
 							}
 							else{
 								response.debug('Cue point url not found in cache for cue point [' + cuePoint.id + ']');
 								if(!entry){
-									This.getEntryAndMetadata(params.partnerId, params.entryId, metadataProfileId, function(entryObj, metadataObj){
+									This.getEntryAndMetadata(params.partnerId, params, metadataProfileId, function(entryObj, metadataObj){
 										entry = entryObj;
 										metadata = metadataObj;
-										This.stitchAd(request, response, params.partnerId, null, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig, params.sessionStartTime);
+										This.stitchAd(request, response, params, null, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
 									});
 								}
 								else{
-									This.stitchAd(request, response, params.partnerId, null, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig, params.sessionStartTime);
+									This.stitchAd(request, response, params, null, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
 								}
 							}
 							}, function (err) {
@@ -155,11 +155,11 @@ KalturaAdIntegrationManager.prototype.stitchCuePoints = function(request, respon
 									This.getEntryAndMetadata(params.partnerId, params.entryId, metadataProfileId, function(entryObj, metadataObj){
 										entry = entryObj;
 										metadata = metadataObj;
-										This.stitchAd(request, response, null, params.partnerId, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig, params.sessionStartTime);
+										This.stitchAd(request, response, null, params, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
 									});
 								}
 								else{
-									This.stitchAd(request, response, null, params.partnerId, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig, params.sessionStartTime);
+									This.stitchAd(request, response, null, params, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, params.sessionId, uiConfConfig);
 								}
 							});
 					}, function(err){
@@ -191,7 +191,7 @@ KalturaAdIntegrationManager.prototype.stitchCuePoints = function(request, respon
  * @param sessionId
  * @param uiConfConfig
  */
-KalturaAdIntegrationManager.prototype.stitchAd = function(request, response, partnerId, cachedUrl, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, sessionId, uiConfConfig, sessionStartTime ) {
+KalturaAdIntegrationManager.prototype.stitchAd = function(request, response, params, cachedUrl, cuePoint, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, sessionId, uiConfConfig) {
 	var This = this;
 
 	var stitchAdForEncodingId = function(cuePointId, renditionId, encodingId, adFileId, adFileInfo){
@@ -205,14 +205,14 @@ KalturaAdIntegrationManager.prototype.stitchAd = function(request, response, par
 				renditionId: renditionId,
 				sharedFilePath: adFileInfo.sharedFilePath
 			};
-			This.callPlayServerService('ad', 'stitch', partnerId, stitchParams);
+			This.callPlayServerService('ad', 'stitch', params.partnerId, stitchParams);
 		}, function (err) {
 			response.debug('Server ad [' + serverAdId + '] already handled');
 		});
 
 	};
 
-	this.getAdMediaFiles(request, response, cuePoint, cachedUrl, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, sessionId, uiConfConfig, sessionStartTime, function(adFileId, adFileInfo){
+	this.getAdMediaFiles(request, response, cuePoint, cachedUrl, entry, metadata, playerConfig, mediaInfos, encodingParamsArr, sessionId, uiConfConfig, params.sessionStartTime, function(adFileId, adFileInfo){
 		response.log('Handling ad file [' + adFileInfo.fileURL + '] session [' + sessionId +']');			
 		for(var i = 0; i < adFileInfo.mediaInfoIds.length; i++){
 			if(adFileInfo.mediaInfoIds[i].trim().length){	

--- a/lib/managers/KalturaAdIntegrationManager.js
+++ b/lib/managers/KalturaAdIntegrationManager.js
@@ -572,11 +572,11 @@ KalturaAdIntegrationManager.prototype.getAdMediaFiles = function(request, respon
 				if (value) {
                     			mapURLandGetMediaFiles();
                 		} else {
-                    			response.error('Session [' + sessionId + '] with sessionStartTime [' + sessionStartTime + '] did not request segments recnetly. Ignoring Vast request');
+                    			response.error('Session [' + sessionId + '] with sessionStartTime [' + sessionStartTime + '] did not request segments recently. Ignoring Vast request');
                 		}	
             		},
 			function(error) {
-				response.error('Session [' + sessionId + '] with sessionStartTime [' + sessionStartTime + '] did not request segments recnetly. Ignoring Vast request');
+				response.error('Session [' + sessionId + '] with sessionStartTime [' + sessionStartTime + '] did not request segments recently. Ignoring Vast request');
             		}
 		);
     	}

--- a/lib/managers/KalturaAdIntegrationManager.js
+++ b/lib/managers/KalturaAdIntegrationManager.js
@@ -545,41 +545,41 @@ KalturaAdIntegrationManager.prototype.getAdMediaFiles = function(request, respon
 	);
 
 	var mapURLandGetMediaFiles = function() {
-        if (cachedUrl == null) {
-            KalturaUrlTokenMapper.mapFixedTokens(request, cuePoint, entry, metadata, playerConfig, function (cachedUrl) {
-                evaluatedUrl = KalturaUrlTokenMapper.mapDynamicTokens(request, cachedUrl, playerConfig);
-                doGetAdMediaFiles(evaluatedUrl);
-            });
-        }
-        else {
-            evaluatedUrl = KalturaUrlTokenMapper.mapDynamicTokens(request, cachedUrl, playerConfig);
-            doGetAdMediaFiles(evaluatedUrl);
-        }
-    };
+        	if (cachedUrl == null) {
+            		KalturaUrlTokenMapper.mapFixedTokens(request, cuePoint, entry, metadata, playerConfig, function (cachedUrl) {
+                		evaluatedUrl = KalturaUrlTokenMapper.mapDynamicTokens(request, cachedUrl, playerConfig);
+                		doGetAdMediaFiles(evaluatedUrl);
+            		});
+        	}
+        	else {
+            		evaluatedUrl = KalturaUrlTokenMapper.mapDynamicTokens(request, cachedUrl, playerConfig);
+            		doGetAdMediaFiles(evaluatedUrl);
+        	}
+    	};
 
 
 	var isNewSession = true;
 	if (sessionStartTime && (sessionStartTime < (Math.floor(Date.now() / 1000) - 1800)))
-        isNewSession = false;
+        	isNewSession = false;
 
 	if (isNewSession) {
-        mapURLandGetMediaFiles();
+        	mapURLandGetMediaFiles();
 	}
 	else {
 		var segmentFetchedKey =  KalturaCache.getKey(KalturaCache.SEGMENT_FETCHED_PREFIX, [sessionId]);
 		KalturaCache.get(segmentFetchedKey,
 			function(value) {
 				if (value) {
-                    mapURLandGetMediaFiles();
-                } else {
-                    response.error('Session [' + sessionId + '] with sessionStartTime [' + sessionStartTime + '] did not request segments recnetly. Ignoring Vast request');
-                }
-            },
+                    			mapURLandGetMediaFiles();
+                		} else {
+                    			response.error('Session [' + sessionId + '] with sessionStartTime [' + sessionStartTime + '] did not request segments recnetly. Ignoring Vast request');
+                		}	
+            		},
 			function(error) {
 				response.error('Session [' + sessionId + '] with sessionStartTime [' + sessionStartTime + '] did not request segments recnetly. Ignoring Vast request');
-            }
+            		}
 		);
-    }
+    	}
 };
 
 /**

--- a/lib/managers/KalturaManifestManager.js
+++ b/lib/managers/KalturaManifestManager.js
@@ -407,12 +407,13 @@ KalturaManifestManager.prototype.getRenditionFromCache = function(request, respo
 		manifestContent = This.replaceManifestTokens(manifestContent, sessionId, playerConfig, sessionStartTime, originDc);
 		
 		This.okResponse(response, manifestContent, 'application/vnd.apple.mpegurl');
-		
+
 		var stitchParams = {
 				entryId: entryId,
 				uiConfConfigId: uiConfConfigId,
 				playerConfig: playerConfig,
-				sessionId: sessionId
+				sessionId: sessionId,
+				sessionStartTime: sessionStartTime
 		};
 			
 		var headers = {

--- a/lib/managers/KalturaMediaManager.js
+++ b/lib/managers/KalturaMediaManager.js
@@ -666,6 +666,8 @@ KalturaMediaManager.prototype.segment = function(request, response, params){
 		this.errorMissingParameter(response);
 		return;
 	}
+	var segmentFetchedKey =  KalturaCache.getKey(KalturaCache.SEGMENT_FETCHED_PREFIX, [params.sessionId]);
+	KalturaCache.set(segmentFetchedKey, 'true', KalturaConfig.config.cache.sessionCuePoint*2)
 
 	var serverAdIdKey = KalturaCache.getKey(KalturaCache.SERVER_AD_ID_KEY_PREFIX, [params.cuePointId, params.renditionId, params.sessionId]);	
 	var canPlayAdKey = KalturaCache.getKey(KalturaCache.CAN_PLAY_AD_KEY_PREFIX, [params.cuePointId, params.sessionId]);

--- a/lib/utils/KalturaCache.js
+++ b/lib/utils/KalturaCache.js
@@ -360,11 +360,14 @@ KalturaCache = {
 		}
 		lifetime = parseInt(lifetime);
 		var stackSource = this.getStack();
-		var cacheTouchCallback = function(err){
+		var cacheTouchCallback = function(err, isNullValue){
 			if(err){
 				var errMessage = 'Cache.touch [' + key + ']:' + err;
 				if(errorCallback){
 					errorCallback(errMessage);
+				}
+				else if(isNullValue){
+	                                KalturaLogger.debug(errMessage);
 				}
 				else{
 					KalturaLogger.error(errMessage + "\n" + stackSource.stack, stackSource);
@@ -378,12 +381,15 @@ KalturaCache = {
 		};
 		
 		if(parseInt(this.config.touchEnabled)){
-			this.server.touch(key, lifetime, function(err){
+			this.server.touch(key, lifetime, function(err, value){
 				if(err){
 					cacheTouchCallback(err);
 				}
-				else{
+				else if(value){
 					cacheTouchCallback();
+				}
+				else{
+					cacheTouchCallback('value is null', true);
 				}
 			});
 		}
@@ -402,7 +408,8 @@ KalturaCache = {
 			});
 		}
 	},
-	
+
+
 	add : function(key, value, lifetime, callback, errorCallback) {
 		if(!lifetime || isNaN(lifetime)){
 			throw new Error('Cache.set [' + key + ']: lifetime [' + lifetime + '] is not numeric');

--- a/lib/utils/KalturaCache.js
+++ b/lib/utils/KalturaCache.js
@@ -44,6 +44,7 @@ KalturaCache = {
 	},
 	
 	//KEY PREFIXES
+	SEGMENT_FETCHED_PREFIX: 'segmentFetched',
 	AD_MEDIA_KEY_PREFIX: 'adMedia',
 	AD_HANDLED_KEY_PREFIX: 'adHandled',
 	
@@ -359,7 +360,7 @@ KalturaCache = {
 		}
 		lifetime = parseInt(lifetime);
 		var stackSource = this.getStack();
-		var cacheTouchCallback = function(err){
+		var cacheTouchCallback = function(data, err){
 			if(err){
 				var errMessage = 'Cache.touch [' + key + ']:' + err;
 				if(errorCallback){
@@ -370,7 +371,10 @@ KalturaCache = {
 				}
 			}
 			else{
-				KalturaLogger.debug('Cache.touch [' + key + ']: OK', stackSource);
+				var msg = "OK";
+				if (data)
+					msg = data;
+				KalturaLogger.debug('Cache.touch [' + key + ']: ' + msg, stackSource);
 				if(callback)
 					callback();
 			}
@@ -379,13 +383,13 @@ KalturaCache = {
 		if(parseInt(this.config.touchEnabled)){
 			this.server.touch(key, lifetime, function(err, value){
 				if(err){
-					cacheTouchCallback(err);
+					cacheTouchCallback(null, err);
 				}
 				else if(value){
 					cacheTouchCallback();
 				}
 				else{
-					cacheTouchCallback('value is null');
+					cacheTouchCallback('value is null', null);
 				}
 			});
 		}
@@ -393,13 +397,13 @@ KalturaCache = {
 			var This = this;
 			this.server.get(key, function(err, value){
 				if(err){
-					cacheTouchCallback(err);
+					cacheTouchCallback(null, err);
 				}
 				else if(value){
 					This.server.set(key, value, lifetime, cacheTouchCallback);
 				}
 				else{
-					cacheTouchCallback('value is null');
+					cacheTouchCallback('value is null', null);
 				}
 			});
 		}

--- a/lib/utils/KalturaCache.js
+++ b/lib/utils/KalturaCache.js
@@ -360,7 +360,7 @@ KalturaCache = {
 		}
 		lifetime = parseInt(lifetime);
 		var stackSource = this.getStack();
-		var cacheTouchCallback = function(data, err){
+		var cacheTouchCallback = function(err){
 			if(err){
 				var errMessage = 'Cache.touch [' + key + ']:' + err;
 				if(errorCallback){
@@ -371,25 +371,19 @@ KalturaCache = {
 				}
 			}
 			else{
-				var msg = "OK";
-				if (data)
-					msg = data;
-				KalturaLogger.debug('Cache.touch [' + key + ']: ' + msg, stackSource);
+				KalturaLogger.debug('Cache.touch [' + key + ']: OK', stackSource);
 				if(callback)
 					callback();
 			}
 		};
 		
 		if(parseInt(this.config.touchEnabled)){
-			this.server.touch(key, lifetime, function(err, value){
+			this.server.touch(key, lifetime, function(err){
 				if(err){
-					cacheTouchCallback(null, err);
-				}
-				else if(value){
-					cacheTouchCallback();
+					cacheTouchCallback(err);
 				}
 				else{
-					cacheTouchCallback('value is null', null);
+					cacheTouchCallback();
 				}
 			});
 		}
@@ -397,18 +391,18 @@ KalturaCache = {
 			var This = this;
 			this.server.get(key, function(err, value){
 				if(err){
-					cacheTouchCallback(null, err);
+					cacheTouchCallback(err);
 				}
 				else if(value){
 					This.server.set(key, value, lifetime, cacheTouchCallback);
 				}
 				else{
-					cacheTouchCallback('value is null', null);
+					cacheTouchCallback('value is null');
 				}
 			});
 		}
 	},
-
+	
 	add : function(key, value, lifetime, callback, errorCallback) {
 		if(!lifetime || isNaN(lifetime)){
 			throw new Error('Cache.set [' + key + ']: lifetime [' + lifetime + '] is not numeric');


### PR DESCRIPTION
Two changes:
1. stop treating cache touch of empty values as errors - this only spam the error log, prints long stack traces.
2. Send Vast request only if:
    - the session is now, meaning created in the last 30 min.
    - the session has requested segments before
This will insure, invalid sessions, which only send rendition requests will not create unneeded vast request and transcoding work.


