### PR TITLE
Pass HTTP x-headers to the VAST request

### DIFF
--- a/lib/managers/KalturaManifestManager.js
+++ b/lib/managers/KalturaManifestManager.js
@@ -268,6 +268,9 @@ KalturaManifestManager.prototype.fetchMaster = function(response, manifestUrl, e
  * @param entryId
  */
 KalturaManifestManager.prototype.master = function(request, response, params){
+        function isXHeader(header) {
+                return (header.startsWith('x-') || header.startsWith('X-'));
+        }
 	function getXForwardedFor()
 	{
 		if (request.headers['x-forwarded-for'])
@@ -319,6 +322,12 @@ KalturaManifestManager.prototype.master = function(request, response, params){
 		'x-forwarded-for': getXForwardedFor(),
 		'user-agent': getUserAgent()
 	};
+	
+	//Pass all 'x-' headers from the request 
+	Object.keys(request.headers).filter(isXHeader).forEach(function(header) {
+                headers[header] = request.headers[header];
+        })
+ 
 	// at this point we have a session id - saving the headers for beacons use later
 	KalturaCache.set(
 		KalturaCache.getKey(KalturaCache.HEADERS_PREFIX, [sessionId]),


### PR DESCRIPTION
This is to allow WN to pass ADID to ad networks